### PR TITLE
Add loading spinners

### DIFF
--- a/src/actions/app-frame.actions.ts
+++ b/src/actions/app-frame.actions.ts
@@ -9,11 +9,25 @@ export namespace AppFrame {
       type = ToggleSidenavExpand.type;
     }
 
+    export class SetPageLoading {
+      static type = 'APP_FRAME_SET_PAGE_LOADING';
+      type = SetPageLoading.type;
+      constructor(public payload: {
+        isPageLoading: boolean
+      }) {}
+    }
+
   }
 
   export const toggleSidenavExpanded = () => (dispatch: Dispatch<Actions.ToggleSidenavExpand>) => {
     dispatch({
       ...new Actions.ToggleSidenavExpand(),
+    });
+  };
+
+  export const setPageLoading = (isPageLoading: boolean) => (dispatch: Dispatch<Actions.SetPageLoading>) => {
+    dispatch({
+      ...new Actions.SetPageLoading({ isPageLoading }),
     });
   };
 

--- a/src/actions/user.actions.ts
+++ b/src/actions/user.actions.ts
@@ -34,6 +34,7 @@ export namespace User {
         userData: ApiUser
       }) {}
     }
+
   }
 
   export const login = () => async (dispatch: Dispatch<Actions.Login>) => {

--- a/src/components/app.styles.ts
+++ b/src/components/app.styles.ts
@@ -15,4 +15,21 @@ export default makeStyles((theme: Theme) => createStyles({
   contentSidenavCollapsed: {
     marginLeft: sidenavWidthCollapsed,
   },
+  contentFaded: {
+    opacity: 0.15,
+  },
+  fixedContentCenteredSidenavExpanded: {
+    paddingLeft: sidenavWidthExpanded / 2,
+    paddingRight: sidenavWidthExpanded / 2,
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+  },
+  fixedContentCenteredSidenavCollapsed: {
+    paddingLeft: sidenavWidthCollapsed / 2,
+    paddingRight: sidenavWidthCollapsed / 2,
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+  },
 }));

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   Switch, Route, Redirect,
 } from 'react-router-dom';
+import { CircularProgress } from '@material-ui/core';
 import { User } from '../actions/user.actions';
 import { AppFrameState } from '../reducers/app-frame.reducer';
 import { UserState } from '../reducers/user.reducer';
@@ -72,30 +73,47 @@ export const App = () => {
             [classes.contentSidenavExpanded]: appFrame.sidenavExpanded,
           })}
         >
-          <Switch>
-            <Route path="/home">
-              <HomePage />
-            </Route>
-            <Route path="/roster">
-              <RosterPage />
-            </Route>
-            <Route path="/workspaces">
-              <WorkspacesPage />
-            </Route>
-            <Route path="/roles">
-              <RoleManagementPage />
-            </Route>
-            <Route path="/users">
-              <UsersPage />
-            </Route>
-            <Route path="/groups">
-              <GroupsPage />
-            </Route>
-            <Route path="/*">
-              <Redirect to="/home" />
-            </Route>
-          </Switch>
+          <div
+            className={clsx({
+              [classes.contentFaded]: appFrame.isPageLoading,
+            })}
+          >
+            <Switch>
+              <Route path="/home">
+                <HomePage />
+              </Route>
+              <Route path="/roster">
+                <RosterPage />
+              </Route>
+              <Route path="/workspaces">
+                <WorkspacesPage />
+              </Route>
+              <Route path="/roles">
+                <RoleManagementPage />
+              </Route>
+              <Route path="/users">
+                <UsersPage />
+              </Route>
+              <Route path="/groups">
+                <GroupsPage />
+              </Route>
+              <Route path="/*">
+                <Redirect to="/home" />
+              </Route>
+            </Switch>
+          </div>
+
+          <div
+            className={clsx(classes.content, {
+              [classes.fixedContentCenteredSidenavCollapsed]: !appFrame.sidenavExpanded,
+              [classes.fixedContentCenteredSidenavExpanded]: appFrame.sidenavExpanded,
+            })}
+          >
+            { appFrame.isPageLoading ? <CircularProgress /> : '' }
+          </div>
+
         </div>
+
       </>
     );
   }

--- a/src/components/buttons/button-with-spinner.styles.ts
+++ b/src/components/buttons/button-with-spinner.styles.ts
@@ -1,0 +1,19 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+export default makeStyles((theme: Theme) => createStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    margin: theme.spacing(0),
+  },
+  wrapper: {
+    position: 'relative',
+  },
+  buttonProgress: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    marginTop: -12,
+    marginLeft: -12,
+  },
+}));

--- a/src/components/buttons/button-with-spinner.tsx
+++ b/src/components/buttons/button-with-spinner.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { Button, ButtonProps } from '@material-ui/core';
+import useStyles from './button-with-spinner.styles';
+
+interface ButtonWithSpinnerProps extends ButtonProps {
+  loading?: boolean
+}
+
+export const ButtonWithSpinner = (props: ButtonWithSpinnerProps) => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.wrapper}>
+        <Button
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...props}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...props.loading ? { disabled: true } : {}}
+        >
+          { props.children }
+        </Button>
+        {props.loading && <CircularProgress size={24} className={classes.buttonProgress} />}
+      </div>
+    </div>
+  );
+};

--- a/src/components/pages/role-management-page/edit-role-dialog.tsx
+++ b/src/components/pages/role-management-page/edit-role-dialog.tsx
@@ -15,6 +15,7 @@ import { ApiRole, ApiWorkspace } from '../../../models/api-response';
 import { AllowedRosterColumns, RosterColumnDisplayName, RosterPIIColumns } from '../../../models/roster-columns';
 import { AllowedNotificationEvents, NotificationEventDisplayName } from '../../../models/notification-events';
 import { parsePermissions, permissionsToArray, setAllPermissions } from '../../../utility/permission-set';
+import { ButtonWithSpinner } from '../../buttons/button-with-spinner';
 
 export interface EditRoleDialogProps {
   open: boolean,
@@ -27,6 +28,7 @@ export interface EditRoleDialogProps {
 
 export const EditRoleDialog = (props: EditRoleDialogProps) => {
   const classes = useStyles();
+
   const [formDisabled, setFormDisabled] = useState(false);
   const {
     open, orgId, role, workspaces, onClose, onError,
@@ -45,6 +47,7 @@ export const EditRoleDialog = (props: EditRoleDialogProps) => {
   const [canViewRoster, setCanViewRoster] = useState(role ? role.canViewRoster : false);
   const [canViewMuster, setCanViewMuster] = useState(role ? role.canViewMuster : false);
   const [canViewPII, setCanViewPII] = useState(role ? role.canViewPII : false);
+  const [saveRoleLoading, setSaveRoleLoading] = useState(false);
 
   if (!open) {
     return <></>;
@@ -115,6 +118,7 @@ export const EditRoleDialog = (props: EditRoleDialogProps) => {
   };
 
   const onSave = async () => {
+    setSaveRoleLoading(true);
     setFormDisabled(true);
     const viewMuster = canManageGroup || canViewMuster;
     const allowedColumns = filterAllowedRosterColumns(viewMuster);
@@ -149,6 +153,7 @@ export const EditRoleDialog = (props: EditRoleDialogProps) => {
       setFormDisabled(false);
       return;
     }
+    setSaveRoleLoading(false);
     if (onClose) {
       onClose();
     }
@@ -367,9 +372,14 @@ export const EditRoleDialog = (props: EditRoleDialogProps) => {
         <Button disabled={formDisabled} variant="outlined" onClick={onClose} color="primary">
           Cancel
         </Button>
-        <Button disabled={!canSave()} onClick={onSave} color="primary">
+        <ButtonWithSpinner
+          disabled={!canSave()}
+          onClick={onSave}
+          color="primary"
+          loading={saveRoleLoading}
+        >
           Save
-        </Button>
+        </ButtonWithSpinner>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/pages/roster-page/roster-page.tsx
+++ b/src/components/pages/roster-page/roster-page.tsx
@@ -7,7 +7,9 @@ import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 import LastPageIcon from '@material-ui/icons/LastPage';
 import React, { ChangeEvent, useEffect, useState } from 'react';
+import axios from 'axios';
 import { useDispatch, useSelector } from 'react-redux';
+import { AppFrame } from '../../../actions/app-frame.actions';
 import { Roster } from '../../../actions/roster.actions';
 import useStyles from './roster-page.styles';
 import { UserState } from '../../../reducers/user.reducer';
@@ -98,12 +100,16 @@ export const RosterPage = () => {
     setRows(rosterResponse);
   };
 
-  function initializeTable() {
-    fetch(`api/roster/${orgId}/count`).then(async response => {
-      const countResponse = (await response.json()) as CountResponse;
-      setRosterSize(countResponse.count);
-      await handleChangePage(null, 0);
-    });
+  async function initializeTable() {
+
+    dispatch(AppFrame.setPageLoading(true));
+
+    const countData = (await axios.get(`api/roster/${orgId}/count`)).data as CountResponse;
+    setRosterSize(countData.count);
+    await handleChangePage(null, 0);
+
+    dispatch(AppFrame.setPageLoading(false));
+
   }
 
   function handleFileInputChange(e: ChangeEvent<HTMLInputElement>) {
@@ -140,7 +146,7 @@ export const RosterPage = () => {
     setAlert({ open: false, message: '', title: '' });
   };
 
-  useEffect(initializeTable, []);
+  useEffect(() => { initializeTable().then(); }, []);
 
   return (
     <main className={classes.root}>

--- a/src/components/pages/user-registration-page/user-registration-page.tsx
+++ b/src/components/pages/user-registration-page/user-registration-page.tsx
@@ -1,5 +1,5 @@
 import {
-  Button, Icon, MenuItem, Paper, TextField,
+  Icon, MenuItem, Paper, TextField,
 } from '@material-ui/core';
 import {
   AssignmentOutlined, DoneAll, FavoriteBorder, LocalHospital, Timeline,
@@ -11,11 +11,13 @@ import { UserState } from '../../../reducers/user.reducer';
 import { AppState } from '../../../store';
 import useStyles from './user-registration-page.styles';
 import services from '../../../data/services';
+import { ButtonWithSpinner } from '../../buttons/button-with-spinner';
 
 export const UserRegistrationPage = () => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const user = useSelector<AppState, UserState>(state => state.user);
+  const [registerUserLoading, setRegisterUserLoading] = useState(false);
   const [inputData, setInputData] = useState<UserRegisterData>({
     firstName: '',
     lastName: '',
@@ -31,8 +33,10 @@ export const UserRegistrationPage = () => {
     });
   }
 
-  function handleCreateAccountClick() {
-    dispatch(User.register(inputData));
+  async function handleCreateAccountClick() {
+    setRegisterUserLoading(true);
+    await dispatch(User.register(inputData));
+    setRegisterUserLoading(false);
   }
 
   function isCreateAccountButtonDisabled() {
@@ -137,14 +141,15 @@ export const UserRegistrationPage = () => {
             </div>
           </form>
 
-          <Button
+          <ButtonWithSpinner
             className={classes.createAccountButton}
             size="large"
             onClick={handleCreateAccountClick}
             disabled={isCreateAccountButtonDisabled()}
+            loading={registerUserLoading}
           >
             Create Account
-          </Button>
+          </ButtonWithSpinner>
         </div>
       </Paper>
     </main>

--- a/src/components/pages/users-page/users-page.styles.ts
+++ b/src/components/pages/users-page/users-page.styles.ts
@@ -16,19 +16,21 @@ export default makeStyles((theme: Theme) => createStyles({
     },
   },
   accessRequestButtons: {
-    display: 'flex',
-    flexFlow: 'row',
-    '& button': {
-      flex: 1,
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    '& div': {
+      width: '100%',
     },
   },
   accessRequestApproveButton: {
+    width: '100%',
     backgroundColor: '#00A91C',
     '&:hover': {
       backgroundColor: '#008C17',
     },
   },
   accessRequestDenyButton: {
+    width: '100%',
     backgroundColor: '#E41D3D',
     marginLeft: '5px',
     '&:hover': {

--- a/src/reducers/app-frame.reducer.ts
+++ b/src/reducers/app-frame.reducer.ts
@@ -2,10 +2,12 @@ import { AppFrame } from '../actions/app-frame.actions';
 
 export interface AppFrameState {
   sidenavExpanded: boolean
+  isPageLoading: boolean
 }
 
 export const appFrameInitialState: AppFrameState = {
   sidenavExpanded: true,
+  isPageLoading: false,
 };
 
 export function appFrameReducer(state = appFrameInitialState, action: any): AppFrameState {
@@ -14,6 +16,12 @@ export function appFrameReducer(state = appFrameInitialState, action: any): AppF
       return {
         ...state,
         sidenavExpanded: !state.sidenavExpanded,
+      };
+    }
+    case AppFrame.Actions.SetPageLoading.type: {
+      return {
+        ...state,
+        isPageLoading: (action as AppFrame.Actions.SetPageLoading).payload.isPageLoading,
       };
     }
     default:


### PR DESCRIPTION
**Here's a high Level of what was added:**

Added page loading spinners to the below pages. The page loading spinner keeps track of state using Redux.
* groups
* roster
* roles
* users

Added a custom button with a loading spinner and then added that button to the below existing buttons. They all keep state locally, except the Create Account button which i used Redux (not sure if that's necessary or not, let me know and I can change it if needed).
* Create Account Button (User Registration page)
* Request Access button (Groups page)
* Finalize Approval button (Users page dialogue)
* Deny Request button (Users page)
* Save Role Button (Role Management page Dialogue)
* Delete Role Button (Role Management page)