### PR TITLE
Fix error in AppToolbar.

### DIFF
--- a/src/components/app-toolbar/app-toolbar.tsx
+++ b/src/components/app-toolbar/app-toolbar.tsx
@@ -62,6 +62,7 @@ export const AppToolbar = () => {
               >
                 {user.roles.map(role => (
                   <MenuItem
+                    key={role.id}
                     selected={user.activeRole!.org!.id === role.org!.id}
                     onClick={handleOrgChanged(role.org!.id)}
                   >


### PR DESCRIPTION
You should no longer see an exception in the console from AppToolbar when the page loads.