### PR TITLE
Set default elasticsearch index on workspace creation

### DIFF
--- a/server/api/workspace/workspace-template.model.ts
+++ b/server/api/workspace/workspace-template.model.ts
@@ -20,7 +20,9 @@ export class WorkspaceTemplate extends BaseEntity {
   @Column()
   phi!: boolean;
 
-  @Column('simple-json')
+  @Column('simple-json', {
+    select: false,
+  })
   kibanaSavedObjects?: any;
 
 }

--- a/server/api/workspace/workspace.controller.ts
+++ b/server/api/workspace/workspace.controller.ts
@@ -27,7 +27,7 @@ class WorkspaceController {
       },
     });
 
-    res.json(workspaces);
+    res.json(workspaces.map(sanitizeWorkspace));
   }
 
   async getOrgWorkspaceTemplates(req: ApiRequest, res: Response) {
@@ -95,7 +95,7 @@ class WorkspaceController {
       await setupKibanaWorkspace(newWorkspace, req.appRole!, req.kibanaApi!);
     });
 
-    await res.status(201).json(newWorkspace);
+    await res.status(201).json(sanitizeWorkspace(newWorkspace!));
   }
 
   async getWorkspace(req: ApiRequest<OrgWorkspaceParams>, res: Response) {
@@ -148,7 +148,7 @@ class WorkspaceController {
     }
 
     const removedWorkspace = await workspace.remove();
-    res.json(removedWorkspace);
+    res.json(sanitizeWorkspace(removedWorkspace));
   }
 
   async updateWorkspace(req: ApiRequest<OrgWorkspaceParams, WorkspaceBody>, res: Response) {
@@ -172,9 +172,17 @@ class WorkspaceController {
 
     const updatedWorkspace = await workspace.save();
 
-    res.json(updatedWorkspace);
+    res.json(sanitizeWorkspace(updatedWorkspace));
   }
 
+}
+
+// Don't return kibana saved objects from workspace endpoints
+function sanitizeWorkspace(workspace: Workspace) {
+  if (workspace.workspaceTemplate) {
+    workspace.workspaceTemplate.kibanaSavedObjects = undefined;
+  }
+  return workspace;
 }
 
 async function setWorkspaceFromBody(workspace: Workspace, body: WorkspaceBody) {

--- a/server/api/workspace/workspace.controller.ts
+++ b/server/api/workspace/workspace.controller.ts
@@ -27,7 +27,7 @@ class WorkspaceController {
       },
     });
 
-    res.json(workspaces.map(sanitizeWorkspace));
+    res.json(workspaces);
   }
 
   async getOrgWorkspaceTemplates(req: ApiRequest, res: Response) {
@@ -95,7 +95,7 @@ class WorkspaceController {
       await setupKibanaWorkspace(newWorkspace, req.appRole!, req.kibanaApi!);
     });
 
-    await res.status(201).json(sanitizeWorkspace(newWorkspace!));
+    await res.status(201).json(newWorkspace);
   }
 
   async getWorkspace(req: ApiRequest<OrgWorkspaceParams>, res: Response) {
@@ -148,7 +148,7 @@ class WorkspaceController {
     }
 
     const removedWorkspace = await workspace.remove();
-    res.json(sanitizeWorkspace(removedWorkspace));
+    res.json(removedWorkspace);
   }
 
   async updateWorkspace(req: ApiRequest<OrgWorkspaceParams, WorkspaceBody>, res: Response) {
@@ -172,17 +172,9 @@ class WorkspaceController {
 
     const updatedWorkspace = await workspace.save();
 
-    res.json(sanitizeWorkspace(updatedWorkspace));
+    res.json(updatedWorkspace);
   }
 
-}
-
-// Don't return kibana saved objects from workspace endpoints
-function sanitizeWorkspace(workspace: Workspace) {
-  if (workspace.workspaceTemplate) {
-    workspace.workspaceTemplate.kibanaSavedObjects = undefined;
-  }
-  return workspace;
 }
 
 async function setWorkspaceFromBody(workspace: Workspace, body: WorkspaceBody) {

--- a/server/app.ts
+++ b/server/app.ts
@@ -64,8 +64,6 @@ app.use(
 
 app.use(
   config.kibana.basePath,
-  requireOrgAccess,
-  requireWorkspaceAccess,
   kibanaProxy,
 );
 

--- a/server/kibana/index.ts
+++ b/server/kibana/index.ts
@@ -1,12 +1,23 @@
-import { Router } from 'express';
+import { Request, Response, Router } from 'express';
 import proxy from 'http-proxy-middleware';
 import kibanaProxySettings from './kibana-proxy-settings';
+import { requireOrgAccess, requireWorkspaceAccess } from '../auth';
 
 const router = Router();
+
+// swallow kibana manifest requests, they do not provide an org cookie and will fail authentication
+router.use(
+  `/ui/favicons/manifest.json`,
+  (req: Request, res: Response) => {
+    res.json({});
+  },
+);
 
 // Proxy client browser to Kibana
 router.use(
   '*',
+  requireOrgAccess,
+  requireWorkspaceAccess,
   proxy(kibanaProxySettings),
 );
 

--- a/server/kibana/kibana-api.ts
+++ b/server/kibana/kibana-api.ts
@@ -3,8 +3,6 @@ import { NextFunction, Response } from 'express';
 import axiosCookieJarSupport from 'axios-cookiejar-support';
 import tough from 'tough-cookie';
 import * as https from 'https';
-import fs from 'fs';
-import process from 'process';
 import { ApiRequest } from '../api';
 import config from '../config';
 import { buildJWT } from './dashboard/read-only-rest.controller';

--- a/server/kibana/kibana-utility.ts
+++ b/server/kibana/kibana-utility.ts
@@ -3,6 +3,7 @@ import { Workspace } from '../api/workspace/workspace.model';
 import { KibanaApi } from './kibana-api';
 import elasticsearch from '../elasticsearch/elasticsearch';
 import { InternalServerError } from '../util/error-types';
+import { WorkspaceTemplate } from '../api/workspace/workspace-template.model';
 
 export async function setupKibanaWorkspace(workspace: Workspace, role: Role, kibanaApi: KibanaApi) {
   if (!workspace.workspaceTemplate) {
@@ -11,7 +12,13 @@ export async function setupKibanaWorkspace(workspace: Workspace, role: Role, kib
 
   const savedObjects = [] as KibanaSavedObject[];
   let defaultIndex: string | undefined;
-  for (const savedObjectRaw of workspace.workspaceTemplate.kibanaSavedObjects) {
+  const templateSavedObjects = (await WorkspaceTemplate.findOne({
+    select: ['kibanaSavedObjects'],
+    where: {
+      id: workspace.workspaceTemplate.id,
+    },
+  }))?.kibanaSavedObjects;
+  for (const savedObjectRaw of templateSavedObjects) {
     savedObjects.push({
       id: savedObjectRaw._id,
       type: savedObjectRaw._type,

--- a/server/kibana/kibana-utility.ts
+++ b/server/kibana/kibana-utility.ts
@@ -1,6 +1,8 @@
 import { Role } from '../api/role/role.model';
 import { Workspace } from '../api/workspace/workspace.model';
 import { KibanaApi } from './kibana-api';
+import elasticsearch from '../elasticsearch/elasticsearch';
+import { InternalServerError } from '../util/error-types';
 
 export async function setupKibanaWorkspace(workspace: Workspace, role: Role, kibanaApi: KibanaApi) {
   if (!workspace.workspaceTemplate) {
@@ -8,15 +10,38 @@ export async function setupKibanaWorkspace(workspace: Workspace, role: Role, kib
   }
 
   const savedObjects = [] as KibanaSavedObject[];
+  let defaultIndex: string | undefined;
   for (const savedObjectRaw of workspace.workspaceTemplate.kibanaSavedObjects) {
     savedObjects.push({
       id: savedObjectRaw._id,
       type: savedObjectRaw._type,
       attributes: savedObjectRaw._source,
     });
+    if (savedObjectRaw._type === 'index-pattern' && savedObjectRaw._source.title === '*') {
+      defaultIndex = savedObjectRaw._id;
+    }
   }
 
   await kibanaApi.axios.post('/api/saved_objects/_bulk_create', savedObjects);
+
+  // Set default index
+  let esVersion: { version: string }[] = [];
+  try {
+    esVersion = await elasticsearch.cat.nodes({
+      format: 'json',
+      h: 'version',
+    });
+  } catch (err) {
+    // We'll handle it with the next check
+  }
+  if (esVersion.length === 0) {
+    throw new InternalServerError('Could not retrieve version from elasticsearch.');
+  }
+  await kibanaApi.axios.post(`/api/saved_objects/config/${esVersion[0].version}`, {
+    attributes: {
+      defaultIndex,
+    },
+  });
 }
 
 interface KibanaSavedObject {


### PR DESCRIPTION
This PR also included the following improvements:

- Update elasticsearch documents when a unit name is changed.
- Fix kibana manifest error spam in logs
- Prevent kibana saved objects from being returned to the client inadvertently