### PR TITLE
Fix incorrect data export url.

### DIFF
--- a/src/components/pages/data-export-page/data-export-page.tsx
+++ b/src/components/pages/data-export-page/data-export-page.tsx
@@ -51,7 +51,7 @@ export const DataExportPage = () => {
     if (endDate) {
       queryParams.push(`endDate=${endDate.toISOString()}`);
     }
-    const response = await fetch(new Request(`api/export/${orgId}?${queryParams.join('&')}`, {
+    const response = await fetch(new Request(`api/export/${orgId}/elasticsearch?${queryParams.join('&')}`, {
       headers: {
         'Content-Type': 'application/octet-stream',
       },


### PR DESCRIPTION
This must have snuck through somehow during the export API PR. Trying to export data was failing with a 404 because the URL was wrong.