### PR TITLE
Fix issue where muster trends included units not in the current group.

### DIFF
--- a/server/api/muster/muster.controller.ts
+++ b/server/api/muster/muster.controller.ts
@@ -8,7 +8,7 @@ import {
   MusterWindow,
 } from '../../util/muster-utils';
 import {
-  ApiRequest, OrgParam, OrgRoleParams, OrgUnitParams, PagedQuery,
+  ApiRequest, OrgRoleParams, OrgUnitParams, PagedQuery,
 } from '../index';
 import { MusterConfiguration, Unit } from '../unit/unit.model';
 import {
@@ -33,13 +33,13 @@ class MusterController {
     });
   }
 
-  async getTrends(req: ApiRequest<OrgParam, null, GetTrendsQuery>, res: Response) {
+  async getTrends(req: ApiRequest<null, null, GetTrendsQuery>, res: Response) {
     const weeksCount = parseInt(req.query.weeksCount ?? '6');
     const monthsCount = parseInt(req.query.monthsCount ?? '6');
 
     const unitRosterCounts = {
-      weekly: await musterUtils.getUnitRosterCounts('week', weeksCount),
-      monthly: await musterUtils.getUnitRosterCounts('month', monthsCount),
+      weekly: await musterUtils.getUnitRosterCounts(req.appOrg!, 'week', weeksCount),
+      monthly: await musterUtils.getUnitRosterCounts(req.appOrg!, 'month', monthsCount),
     };
 
     // Get unique dates and unit names.

--- a/server/api/muster/muster.controller.ts
+++ b/server/api/muster/muster.controller.ts
@@ -38,8 +38,8 @@ class MusterController {
     const monthsCount = parseInt(req.query.monthsCount ?? '6');
 
     const unitRosterCounts = {
-      weekly: await musterUtils.getUnitRosterCounts(req.appOrg!, 'week', weeksCount),
-      monthly: await musterUtils.getUnitRosterCounts(req.appOrg!, 'month', monthsCount),
+      weekly: await musterUtils.getUnitRosterCounts(req.appRole!, 'week', weeksCount),
+      monthly: await musterUtils.getUnitRosterCounts(req.appRole!, 'month', monthsCount),
     };
 
     // Get unique dates and unit names.

--- a/server/util/muster-utils.ts
+++ b/server/util/muster-utils.ts
@@ -151,14 +151,16 @@ export const musterUtils = {
     });
   },
 
-  async getUnitRosterCounts(org: Org, interval: 'week' | 'month', intervalCount: number) {
+  async getUnitRosterCounts(role: Role, interval: 'week' | 'month', intervalCount: number) {
     const momentUnitOfTime = {
       week: 'isoWeek',
       month: 'month',
     }[interval] as unitOfTime.StartOf;
 
     const params = [] as any[];
-    const orgIdParamIndex = addParam(params, org.id);
+    const orgIdParamIndex = addParam(params, role.org!.id);
+    const unitFilter = role.getUnitFilter().replace('*', '%');
+    const unitFilterParamIndex = addParam(params, unitFilter);
 
     // Query the number of individuals grouped by unit who were active between the start/end dates.
     // NOTE: There may be a more efficient way of doing this where we don't require a union of multiple queries, but this
@@ -175,6 +177,7 @@ export const musterUtils = {
         FROM roster
         WHERE
           unit_org = $${orgIdParamIndex} AND
+          unit_id LIKE $${unitFilterParamIndex} AND
           (start_date IS null AND (end_date IS null OR end_date > $${endDateParamIndex}::date))
           OR (start_date <= $${startDateParamIndex}::date AND (end_date IS null OR end_date > $${endDateParamIndex}::date))
         GROUP BY "unitId"

--- a/server/util/muster-utils.ts
+++ b/server/util/muster-utils.ts
@@ -151,11 +151,14 @@ export const musterUtils = {
     });
   },
 
-  async getUnitRosterCounts(interval: 'week' | 'month', intervalCount: number) {
+  async getUnitRosterCounts(org: Org, interval: 'week' | 'month', intervalCount: number) {
     const momentUnitOfTime = {
       week: 'isoWeek',
       month: 'month',
     }[interval] as unitOfTime.StartOf;
+
+    const params = [] as any[];
+    const orgIdParamIndex = addParam(params, org.id);
 
     // Query the number of individuals grouped by unit who were active between the start/end dates.
     // NOTE: There may be a more efficient way of doing this where we don't require a union of multiple queries, but this
@@ -165,19 +168,22 @@ export const musterUtils = {
     for (let i = 0; i < intervalCount; i++) {
       const startDate = moment.utc().subtract(i + 1, interval).startOf(momentUnitOfTime).format(musterUtils.dateFormat);
       const endDate = moment.utc(startDate).add(1, interval).format(musterUtils.dateFormat);
+      const startDateParamIndex = addParam(params, startDate);
+      const endDateParamIndex = addParam(params, endDate);
       queries.push(`
-        SELECT unit_id as "unitId", count(id), '${startDate}' as date
+        SELECT unit_id as "unitId", count(id), $${startDateParamIndex}::varchar as date
         FROM roster
         WHERE
-          (start_date IS null AND (end_date IS null OR end_date > '${endDate}'))
-          OR (start_date <= '${startDate}' AND (end_date IS null OR end_date > '${endDate}'))
+          unit_org = $${orgIdParamIndex} AND
+          (start_date IS null AND (end_date IS null OR end_date > $${endDateParamIndex}::date))
+          OR (start_date <= $${startDateParamIndex}::date AND (end_date IS null OR end_date > $${endDateParamIndex}::date))
         GROUP BY "unitId"
       `);
 
       dates.add(startDate);
     }
 
-    const rows = await getConnection().query(queries.join(`UNION`)) as {
+    const rows = await getConnection().query(queries.join(`UNION`), params) as {
       unitId: string
       date: string
       count: string
@@ -254,6 +260,11 @@ export const musterUtils = {
   },
 
 };
+
+function addParam(params: any[], data: any) {
+  params.push(data);
+  return params.length;
+}
 
 export type MusterIndividual = {
   nonMusterPercent: number


### PR DESCRIPTION
The muster trends query wasn't filtering by org id. I also made that query parameterized just to be safe.