### PR TITLE
Affiliation list updates

### DIFF
--- a/server/migration/1607616094276-ContractorAffiliationUpdate.ts
+++ b/server/migration/1607616094276-ContractorAffiliationUpdate.ts
@@ -1,0 +1,13 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ContractorAffiliationUpdate1607616094276 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`UPDATE "user" SET "service"='Other' WHERE "service"='Contractor'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`UPDATE "user" SET "service"='Contractor' WHERE "service"='Other'`);
+    }
+
+}

--- a/server/migration/1607616094276-ContractorAffiliationUpdate.ts
+++ b/server/migration/1607616094276-ContractorAffiliationUpdate.ts
@@ -2,12 +2,11 @@ import {MigrationInterface, QueryRunner} from "typeorm";
 
 export class ContractorAffiliationUpdate1607616094276 implements MigrationInterface {
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-      await queryRunner.query(`UPDATE "user" SET "service"='Other' WHERE "service"='Contractor'`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`UPDATE "user" SET "service"='Other' WHERE "service"='Contractor'`);
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-      await queryRunner.query(`UPDATE "user" SET "service"='Contractor' WHERE "service"='Other'`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`UPDATE "user" SET "service"='Contractor' WHERE "service"='Other'`);
+  }
 }

--- a/server/migration/1607616094276-ContractorAffiliationUpdate.ts
+++ b/server/migration/1607616094276-ContractorAffiliationUpdate.ts
@@ -1,12 +1,12 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class ContractorAffiliationUpdate1607616094276 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`UPDATE "user" SET "service"='Other' WHERE "service"='Contractor'`);
+    await queryRunner.query(`UPDATE "user" SET "service"='Other' WHERE "service" = 'Contractor'`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`UPDATE "user" SET "service"='Contractor' WHERE "service"='Other'`);
+    await queryRunner.query(`UPDATE "user" SET "service"='Contractor' WHERE "service" = 'Other'`);
   }
 }

--- a/server/migration/1607616094276-ContractorAffiliationUpdate.ts
+++ b/server/migration/1607616094276-ContractorAffiliationUpdate.ts
@@ -1,4 +1,4 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class ContractorAffiliationUpdate1607616094276 implements MigrationInterface {
 

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -1,8 +1,12 @@
 export default [
   'Air Force',
   'Army',
+  'Coast Guard',
+  'DOD/OSD',
+  'DOD/OSD/DDS',
+  'DOD/DHA',
   'Marine Corps',
   'Navy',
   'Space Force',
-  'Contractor',
+  'Other',
 ];


### PR DESCRIPTION
Updates the service affiliation list for new user registration to use these values:
[
  'Air Force',
  'Army',
  'Coast Guard',
  'DOD/OSD',
  'DOD/OSD/DDS',
  'DOD/DHA',
  'Marine Corps',
  'Navy',
  'Space Force',
  'Other',
];
Most are additions, but does remove the 'Contractor' affiliation and replaces with 'Other'.
Contains corresponding DB migration updating any existing 'Contractor' users to the new 'Other' affiliation.