### PR TITLE
Custom Link component to handle internal and external links.

### DIFF
--- a/src/components/app-sidenav/app-sidenav.tsx
+++ b/src/components/app-sidenav/app-sidenav.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import {
-  Divider, Drawer, IconButton, List, ListItem, ListItemIcon, ListItemText,
+  Divider,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
 } from '@material-ui/core';
 import BarChartIcon from '@material-ui/icons/BarChart';
 import HomeIcon from '@material-ui/icons/Home';
@@ -12,51 +18,56 @@ import ViewWeekOutlinedIcon from '@material-ui/icons/ViewWeekOutlined';
 import DashboardOutlinedIcon from '@material-ui/icons/DashboardOutlined';
 import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
 import clsx from 'clsx';
-import { useDispatch, useSelector } from 'react-redux';
-import { Link, useLocation } from 'react-router-dom';
+import {
+  useDispatch,
+  useSelector,
+} from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { AppFrameState } from '../../reducers/app-frame.reducer';
 import { UserState } from '../../reducers/user.reducer';
+import { UserSelector } from '../../selectors/user.selector';
 import { AppState } from '../../store';
 import { PersonCheckIcon } from '../icons/person-check-icon';
+import {
+  Link,
+  LinkProps,
+} from '../link/link';
 import useStyles from './app-sidenav.styles';
 import { AppFrame } from '../../actions/app-frame.actions';
 import { DataExportIcon } from '../icons/data-export-icon';
 
-interface SidenavLinkProps {
-  route: string,
+type SidenavLinkProps = {
   name: string,
   icon: any,
-  external?: boolean,
-}
+} & LinkProps;
 
 const SidenavLink = (props: SidenavLinkProps) => {
+  const {
+    name,
+    icon,
+  } = props;
   const classes = useStyles();
   const location = useLocation();
+
   const isActive = () => {
-    return location.pathname.endsWith(props.route);
-  };
-  const inner = () => {
-    return (
-      <ListItem button key={props.name}>
-        <ListItemIcon>{props.icon}</ListItemIcon>
-        <ListItemText primary={props.name} />
-      </ListItem>
-    );
+    // Only internal links can be active.
+    if ('to' in props) {
+      return location.pathname.endsWith(props.to as string);
+    }
+
+    return false;
   };
 
   return (
-    <>
-      {props.external && (
-        <a href={props.route} className={isActive() ? classes.activeLink : classes.inactiveLink}>
-          {inner()}
-        </a>
-      )}
-      {!props.external && (
-        <Link to={props.route} className={isActive() ? classes.activeLink : classes.inactiveLink}>
-          {inner()}
-        </Link>
-      )}
-    </>
+    <Link
+      className={isActive() ? classes.activeLink : classes.inactiveLink}
+      {...props}
+    >
+      <ListItem button key={name}>
+        <ListItemIcon>{icon}</ListItemIcon>
+        <ListItemText primary={name} />
+      </ListItem>
+    </Link>
   );
 };
 
@@ -64,6 +75,7 @@ export const AppSidenav = () => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const user = useSelector<AppState, UserState>(state => state.user);
+  const orgId = useSelector(UserSelector.orgId);
   const appFrame = useSelector<AppState, AppFrameState>(state => state.appFrame);
 
   const toggleSidenav = () => {
@@ -99,35 +111,34 @@ export const AppSidenav = () => {
 
         <List>
           <SidenavLink
-            route="/home"
+            to="/home"
             name="Home"
             icon={(<HomeIcon />)}
           />
           {user.activeRole?.workspace && (
             <SidenavLink
-              external
-              route={`/dashboard?orgId=${user.activeRole?.org?.id}`}
+              href={`/dashboard?orgId=${orgId}`}
               name="Analytics"
               icon={(<BarChartIcon />)}
             />
           )}
           {user.activeRole?.workspace && (
             <SidenavLink
-              route="/data-export"
+              to="/data-export"
               name="Data Export"
               icon={(<DataExportIcon />)}
             />
           )}
           {user.activeRole?.canViewMuster && (
             <SidenavLink
-              route="/muster"
+              to="/muster"
               name="Muster"
               icon={(<PersonCheckIcon />)}
             />
           )}
           {user.activeRole?.canViewRoster && (
             <SidenavLink
-              route="/roster"
+              to="/roster"
               name="Roster"
               icon={(<AssignmentIndIcon />)}
             />
@@ -146,27 +157,27 @@ export const AppSidenav = () => {
 
             <List>
               <SidenavLink
-                route="/units"
+                to="/units"
                 name="Units"
                 icon={(<GroupWorkIcon />)}
               />
               <SidenavLink
-                route="/users"
+                to="/users"
                 name="Users"
                 icon={(<SupervisorAccountIcon />)}
               />
               <SidenavLink
-                route="/roles"
+                to="/roles"
                 name="Roles"
                 icon={(<SecurityIcon />)}
               />
               <SidenavLink
-                route="/roster-columns"
+                to="/roster-columns"
                 name="Roster Columns"
                 icon={(<ViewWeekOutlinedIcon />)}
               />
               <SidenavLink
-                route="/workspaces"
+                to="/workspaces"
                 name="Workspaces"
                 icon={(<DashboardOutlinedIcon />)}
               />

--- a/src/components/app-toolbar/app-toolbar.tsx
+++ b/src/components/app-toolbar/app-toolbar.tsx
@@ -2,11 +2,10 @@ import {
   AppBar, Avatar, Button, Divider, Menu, MenuItem, Toolbar,
 } from '@material-ui/core';
 import { ArrowDropDown, Settings } from '@material-ui/icons';
-
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { Md5 } from 'ts-md5/dist/md5';
+import { Link } from '../link/link';
 import { User } from '../../actions/user.actions';
 import { UserState } from '../../reducers/user.reducer';
 import { AppState } from '../../store';

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {
+  Link as MuiLink,
+  LinkProps as MuiLinkProps,
+} from '@material-ui/core';
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+} from 'react-router-dom';
+
+export type ExternalLinkProps = MuiLinkProps;
+export type InternalLinkProps = MuiLinkProps & RouterLinkProps;
+export type LinkProps = ExternalLinkProps | InternalLinkProps;
+
+export const Link = (props: LinkProps) => {
+  return (
+    <>
+      {props.href ? (
+        <MuiLink {...props} />
+      ) : (
+        <MuiLink component={RouterLink} {...props} />
+      )}
+    </>
+  );
+};

--- a/src/components/pages/home-page/home-page.tsx
+++ b/src/components/pages/home-page/home-page.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import {
-  Button, Card, CardActions, CardContent, Container, Grid, Typography,
+  Card, CardContent, Container, Grid, Typography,
 } from '@material-ui/core';
-import { Link } from 'react-router-dom';
+import { UserSelector } from '../../../selectors/user.selector';
+import { Link } from '../../link/link';
 import { UserState } from '../../../reducers/user.reducer';
 import { AppState } from '../../../store';
 import useStyles from './home-page.styles';
@@ -11,6 +12,7 @@ import welcomeImage from '../../../media/images/welcome-image.png';
 
 export const HomePage = () => {
   const user = useSelector<AppState, UserState>(state => state.user);
+  const orgId = useSelector(UserSelector.orgId);
   const classes = useStyles();
 
   return (
@@ -28,34 +30,44 @@ export const HomePage = () => {
                     </Typography>
 
                     <Typography gutterBottom>
-                      With Status Engine you can easily monitor COVID-19 cases across your entire organization. If you have any questions, comments or concerns please reach out to us by email at <a href="mailto:covid19feedback@dds.mil">covid19feedback@dds.mil</a>.
+                      With Status Engine you can easily monitor COVID-19 cases across your entire organization. If you
+                      have any questions, comments or concerns please reach out to us by email at&nbsp;
+                      <Link href="mailto:covid19feedback@dds.mil" target="_blank">covid19feedback@dds.mil</Link>.
                     </Typography>
 
                     <ul>
                       {user.activeRole?.canViewRoster && (
                         <li>
                           <Typography>
-                            <strong><Link to="/roster">Roster Management</Link><br /></strong> Manage your organization’s roster with the built-in suite of tools designed to allow for quick and easy modifications.
+                            <strong><Link to="/roster">Roster Management</Link></strong><br />
+                            Manage your organization&apos;s roster with the built-in suite of tools designed to allow for
+                            quick and easy modifications.
                           </Typography>
                         </li>
                       )}
                       {user.activeRole?.canViewMuster && (
                         <li>
                           <Typography>
-                            <strong><Link to="/muster">Muster Snapshot</Link><br /></strong> Track your group's daily muster compliance, view weekly and monthly trends, as well as export data.
+                            <strong><Link to="/muster">Muster Snapshot</Link></strong><br />
+                            Track your group&apos;s daily muster compliance, view weekly and monthly trends, as well as
+                            export data.
                           </Typography>
                         </li>
                       )}
                       {user.activeRole?.workspace && (
                         <li>
                           <Typography>
-                            <strong><Link to={`/dashboard?orgId=${user.activeRole?.org?.id}`}>Customizeable Dashboards</Link><br /></strong>  Protect sensitive data by creating and assigning role-based permissions across the entire organization.
+                            <strong><Link href={`/dashboard?orgId=${orgId}`}>Customizable Dashboards</Link></strong><br />
+                            Protect sensitive data by creating and assigning role-based permissions across the entire
+                            organization.
                           </Typography>
                         </li>
                       )}
                       <li>
                         <Typography>
-                          <strong><Link to="/settings">Alerts &amp; Notifications</Link><br /></strong> Stay up-to-date on organization activity without overburdening your inbox or mobile device with fully customizeable alerts.
+                          <strong><Link to="/settings">Alerts &amp; Notifications</Link></strong><br />
+                          Stay up-to-date on organization activity without overburdening your inbox or mobile device
+                          with fully customizable alerts.
                         </Typography>
                       </li>
                     </ul>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -203,6 +203,9 @@ theme.props = {
   MuiInput: {
     disableUnderline: true,
   },
+  MuiLink: {
+    underline: 'none',
+  },
   MuiTextField: {
     InputLabelProps: {
       shrink: true,


### PR DESCRIPTION
This should unify the Link component so that we can use the same thing for internal and external links. To link internally, you should pass a `to` prop, and to link externally you should pass an `href` prop.

This PR also fixes a bug where the "Customizable Dashboards" link on the home page didn't work.