### PR TITLE
Muster backend updates leveraging new ES data structure.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -64,6 +64,7 @@
     ],
     "no-underscore-dangle": "off",
     "no-use-before-define": "off",
+    "object-curly-newline": ["error", { "consistent": true }],
     "padded-blocks": "off",
     "prefer-destructuring": "off",
     "radix": "off",

--- a/migration-revert.sh
+++ b/migration-revert.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+npm run typeorm -- migration:revert

--- a/server/api/export/export.controller.ts
+++ b/server/api/export/export.controller.ts
@@ -7,9 +7,9 @@ import {
   ForbiddenError,
   InternalServerError,
 } from '../../util/error-types';
-import { musterUtils } from '../../util/muster-utils';
+import { getRosterMusterStats } from '../../util/muster-utils';
 import {
-  requireQuery,
+  assertRequestQuery,
   TimeInterval,
 } from '../../util/util';
 import {
@@ -126,7 +126,7 @@ class ExportController {
   }
 
   async exportMusterIndividualsToCsv(req: ApiRequest<OrgParam, null, ExportMusterIndividualsQuery>, res: Response) {
-    requireQuery(req, [
+    assertRequestQuery(req, [
       'interval',
       'intervalCount',
     ]);
@@ -134,7 +134,7 @@ class ExportController {
     const interval = req.query.interval;
     const intervalCount = parseInt(req.query.intervalCount);
 
-    const individuals = await musterUtils.getRosterMusterStats({
+    const individuals = await getRosterMusterStats({
       org: req.appOrg!,
       role: req.appRole!,
       interval,

--- a/server/api/export/export.controller.ts
+++ b/server/api/export/export.controller.ts
@@ -9,6 +9,10 @@ import {
 } from '../../util/error-types';
 import { musterUtils } from '../../util/muster-utils';
 import {
+  requireQuery,
+  TimeInterval,
+} from '../../util/util';
+import {
   ApiRequest,
   OrgParam,
   PagedQuery,
@@ -122,9 +126,21 @@ class ExportController {
   }
 
   async exportMusterIndividualsToCsv(req: ApiRequest<OrgParam, null, ExportMusterIndividualsQuery>, res: Response) {
-    const intervalCount = parseInt(req.query.intervalCount ?? '1');
+    requireQuery(req, [
+      'interval',
+      'intervalCount',
+    ]);
 
-    const individuals = await musterUtils.getIndividualsData(req.appOrg!, req.appRole!, intervalCount, req.query.unitId);
+    const interval = req.query.interval;
+    const intervalCount = parseInt(req.query.intervalCount);
+
+    const individuals = await musterUtils.getRosterMusterStats({
+      org: req.appOrg!,
+      role: req.appRole!,
+      interval,
+      intervalCount,
+      unitId: req.query.unitId,
+    });
 
     // Delete roster ids since they're meaningless to the user.
     for (const individual of individuals) {
@@ -146,8 +162,9 @@ type ExportOrgQuery = {
 };
 
 type ExportMusterIndividualsQuery = {
+  interval: TimeInterval
   intervalCount: string
-  unitId: string
+  unitId?: string
 } & PagedQuery;
 
 export default new ExportController();

--- a/server/api/muster/muster.controller.ts
+++ b/server/api/muster/muster.controller.ts
@@ -1,29 +1,50 @@
-import moment from 'moment-timezone';
-import { MSearchResponse } from 'elasticsearch';
 import { Response } from 'express';
-import elasticsearch from '../../elasticsearch/elasticsearch';
-import { InternalServerError, NotFoundError } from '../../util/error-types';
+import { NotFoundError } from '../../util/error-types';
 import {
   musterUtils,
   MusterWindow,
 } from '../../util/muster-utils';
 import {
-  ApiRequest, OrgRoleParams, OrgUnitParams, PagedQuery,
+  ApiRequest,
+  OrgRoleParams,
+  OrgUnitParams,
+  PagedQuery,
 } from '../index';
-import { MusterConfiguration, Unit } from '../unit/unit.model';
 import {
-  dayIsIn, DaysOfTheWeek, nextDay, oneDaySeconds,
+  MusterConfiguration,
+  Unit,
+} from '../unit/unit.model';
+import {
+  dayIsIn,
+  DaysOfTheWeek,
+  nextDay,
+  oneDaySeconds,
+  requireQuery,
+  TimeInterval,
 } from '../../util/util';
 
 class MusterController {
 
-  // TODO: Support custom muster intervals.
   async getIndividuals(req: ApiRequest<OrgRoleParams, null, GetIndividualsQuery>, res: Response) {
-    const intervalCount = parseInt(req.query.intervalCount ?? '1');
-    const limit = parseInt(req.query.limit ?? '10');
-    const page = parseInt(req.query.page ?? '0');
+    requireQuery(req, [
+      'interval',
+      'intervalCount',
+      'limit',
+      'page',
+    ]);
 
-    const individuals = await musterUtils.getIndividualsData(req.appOrg!, req.appRole!, intervalCount, req.query.unitId);
+    const interval = req.query.interval;
+    const intervalCount = parseInt(req.query.intervalCount);
+    const limit = parseInt(req.query.limit);
+    const page = parseInt(req.query.page);
+
+    const individuals = await musterUtils.getRosterMusterStats({
+      org: req.appOrg!,
+      role: req.appRole!,
+      interval,
+      intervalCount,
+      unitId: req.query.unitId || undefined,
+    });
 
     const offset = page * limit;
 
@@ -34,230 +55,21 @@ class MusterController {
   }
 
   async getTrends(req: ApiRequest<null, null, GetTrendsQuery>, res: Response) {
+    requireQuery(req, [
+      'weeksCount',
+      'monthsCount',
+    ]);
+
     const weeksCount = parseInt(req.query.weeksCount ?? '6');
     const monthsCount = parseInt(req.query.monthsCount ?? '6');
 
-    const unitRosterCounts = {
-      weekly: await musterUtils.getUnitRosterCounts(req.appRole!, 'week', weeksCount),
-      monthly: await musterUtils.getUnitRosterCounts(req.appRole!, 'month', monthsCount),
-    };
+    const unitTrends = await musterUtils.getUnitMusterStats({
+      role: req.appRole!,
+      weeksCount,
+      monthsCount,
+    });
 
-    // Get unique dates and unit names.
-    const weeklyDates = new Set<string>();
-    const monthlyDates = new Set<string>();
-    const unitIds = new Set<string>();
-
-    for (const date of Object.keys(unitRosterCounts.weekly)) {
-      weeklyDates.add(date);
-
-      for (const unitId of Object.keys(unitRosterCounts.weekly[date])) {
-        unitIds.add(unitId);
-      }
-    }
-
-    for (const date of Object.keys(unitRosterCounts.monthly)) {
-      monthlyDates.add(date);
-
-      for (const unitId of Object.keys(unitRosterCounts.monthly[date])) {
-        unitIds.add(unitId);
-      }
-    }
-
-    //
-    // Build elastcisearch multisearch queries.
-    //
-    const esBody = [] as any[];
-
-    // Weekly ES Queries
-    for (const unitId of unitIds) {
-      esBody.push({
-        index: req.appRole!.getKibanaIndexForMuster(unitId),
-      });
-      esBody.push({
-        size: 0,
-        query: {
-          bool: {
-            must: [{
-              range: {
-                Timestamp: {
-                  gte: `now-${weeksCount}w/w`,
-                  lt: 'now/w',
-                },
-              },
-            }],
-          },
-        },
-        aggs: {
-          reportsHistogram: {
-            date_histogram: {
-              field: 'Timestamp',
-              interval: 'week',
-            },
-          },
-        },
-      });
-    }
-
-    // Monthly ES Queries
-    for (const unitId of unitIds) {
-      esBody.push({
-        index: req.appRole!.getKibanaIndexForMuster(unitId),
-      });
-      esBody.push({
-        size: 0,
-        query: {
-          bool: {
-            must: [{
-              range: {
-                Timestamp: {
-                  gte: `now-${monthsCount}M/M`,
-                  lt: 'now/M',
-                },
-              },
-            }],
-          },
-        },
-        aggs: {
-          reportsHistogram: {
-            date_histogram: {
-              field: 'Timestamp',
-              interval: 'month',
-            },
-          },
-        },
-      });
-    }
-
-    // Send request.
-    let response: MSearchResponse<unknown>;
-    try {
-      response = await elasticsearch.msearch({ body: esBody });
-    } catch (err) {
-      throw new InternalServerError(`Elasticsearch: ${err.message}`);
-    }
-
-    //
-    // Calculate and organize data.
-    //
-    type UnitStatsByDate = {
-      [date: string]: {
-        [unitId: string]: {
-          nonMusterPercent: number,
-          reportsCount: number
-          rosterCount: number
-        }
-      }
-    };
-
-    const unitStats = {
-      weekly: {} as UnitStatsByDate,
-      monthly: {} as UnitStatsByDate,
-    };
-
-    // Weekly
-    for (const date of weeklyDates) {
-      unitStats.weekly[date] = {};
-    }
-
-    let responseIndex = 0;
-    for (const unitId of unitIds) {
-      let buckets: {
-        key_as_string: string
-        key: number
-        doc_count: number
-      }[];
-      if (!response.responses![responseIndex].aggregations) {
-        buckets = [];
-      } else {
-        buckets = response.responses![responseIndex].aggregations.reportsHistogram.buckets as {
-          key_as_string: string
-          key: number
-          doc_count: number
-        }[];
-      }
-
-      for (const bucket of buckets) {
-        const date = moment.utc(bucket.key).format(musterUtils.dateFormat);
-        const reportsCount = bucket.doc_count;
-        const rosterCount = unitRosterCounts.weekly[date][unitId];
-
-        const nextWeek = moment.utc(date).add(1, 'week');
-        const maxReportsCount = rosterCount * nextWeek.diff(date, 'days');
-
-        unitStats.weekly[date][unitId] = {
-          nonMusterPercent: musterUtils.calcNonMusterPercent(reportsCount, maxReportsCount),
-          rosterCount,
-          reportsCount,
-        };
-      }
-      responseIndex += 1;
-    }
-
-    // Any units that weren't found must not have any reports. Add them manually.
-    for (const date of weeklyDates) {
-      for (const unitId of unitIds) {
-        if (!unitStats.weekly[date][unitId]) {
-          unitStats.weekly[date][unitId] = {
-            nonMusterPercent: 100,
-            rosterCount: unitRosterCounts.weekly[date][unitId],
-            reportsCount: 0,
-          };
-        }
-      }
-    }
-
-    // Monthly
-    for (const date of monthlyDates) {
-      unitStats.monthly[date] = {};
-    }
-
-    for (const unitId of unitIds) {
-      let buckets: {
-        key_as_string: string
-        key: number
-        doc_count: number
-      }[];
-      if (!response.responses![responseIndex].aggregations) {
-        buckets = [];
-      } else {
-        buckets = response.responses![responseIndex].aggregations.reportsHistogram.buckets as {
-          key_as_string: string
-          key: number
-          doc_count: number
-        }[];
-      }
-
-      for (const bucket of buckets) {
-        const date = moment.utc(bucket.key).format(musterUtils.dateFormat);
-        const reportsCount = bucket.doc_count;
-        const rosterCount = unitRosterCounts.monthly[date][unitId];
-
-        const nextMonth = moment.utc(date).add(1, 'month');
-        const maxReportsCount = rosterCount * nextMonth.diff(date, 'days');
-
-        unitStats.monthly[date][unitId] = {
-          nonMusterPercent: musterUtils.calcNonMusterPercent(reportsCount, maxReportsCount),
-          rosterCount,
-          reportsCount,
-        };
-      }
-      responseIndex += 1;
-    }
-
-    // Any units that weren't found must not have any reports. Add them manually.
-    for (const date of monthlyDates) {
-      for (const unitId of unitIds) {
-        if (!unitStats.monthly[date][unitId]) {
-          unitStats.monthly[date][unitId] = {
-            nonMusterPercent: 100,
-            rosterCount: unitRosterCounts.monthly[date][unitId],
-            reportsCount: 0,
-          };
-        }
-      }
-    }
-
-    res.json(unitStats);
+    res.json(unitTrends);
   }
 
   async getClosedMusterWindows(req: ApiRequest<null, null, GetClosedMusterWindowsQuery>, res: Response) {
@@ -365,6 +177,7 @@ class MusterController {
 }
 
 type GetIndividualsQuery = {
+  interval: TimeInterval
   intervalCount: string
   unitId: string
 } & PagedQuery;

--- a/server/api/unit/unit.model.ts
+++ b/server/api/unit/unit.model.ts
@@ -1,9 +1,16 @@
 import {
-  Entity, Column, BaseEntity, JoinColumn, ManyToOne, PrimaryColumn,
+  Entity,
+  Column,
+  BaseEntity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  Index,
 } from 'typeorm';
 import { Org } from '../org/org.model';
 
 @Entity()
+@Index(['org', 'name'], { unique: true })
 export class Unit extends BaseEntity {
 
   @PrimaryColumn()

--- a/server/migration/1610732290560-UnitNameIndex.ts
+++ b/server/migration/1610732290560-UnitNameIndex.ts
@@ -1,0 +1,16 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+} from 'typeorm';
+
+export class UnitNameIndex1610732290560 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE UNIQUE INDEX "IDX_232f43836beace9d8657a8a4c8" ON "unit" ("org_id", "name") `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_232f43836beace9d8657a8a4c8"`);
+  }
+
+}

--- a/server/util/muster-utils.ts
+++ b/server/util/muster-utils.ts
@@ -1,6 +1,9 @@
-import { SearchResponse } from 'elasticsearch';
-import moment, { unitOfTime } from 'moment-timezone';
-import { getConnection } from 'typeorm';
+import {
+  MSearchResponse,
+  SearchResponse,
+} from 'elasticsearch';
+import moment from 'moment-timezone';
+import { Like } from 'typeorm';
 import { Org } from '../api/org/org.model';
 import { Role } from '../api/role/role.model';
 import { Roster } from '../api/roster/roster.model';
@@ -10,17 +13,44 @@ import {
 } from '../api/unit/unit.model';
 import elasticsearch from '../elasticsearch/elasticsearch';
 import { InternalServerError } from './error-types';
+import {
+  getEsDateFormat,
+  getEsTimeInterval,
+  getMomentDateFormat,
+  TimeInterval,
+} from './util';
 
 export const musterUtils = {
 
-  get dateFormat() {
-    return 'YYYY-MM-DD';
-  },
+  /**
+   * Get muster stats for each individual on the roster, given a time range and optional unit to filter by. The returned
+   * data will include each individual's muster stats merged with their roster data.
+   */
+  async getRosterMusterStats(args: {
+    org: Org
+    role: Role
+    interval: TimeInterval
+    intervalCount: number
+    unitId?: string
+  }) {
+    const { org, role, interval, intervalCount, unitId } = args;
 
-  async getIndividualsData(org: Org, role: Role, intervalCount: number, unitId?: string) {
-    // HACK: The database queries in this function are extremely inefficient for large rosters, and need to be revised
-    // once the new elasticsearch muster data architecture is put in place.
+    // Send ES request.
+    let response: SearchResponse<never>;
+    try {
+      response = await elasticsearch.search({
+        index: role.getKibanaIndexForMuster(unitId),
+        body: buildIndividualsMusterBody({
+          interval,
+          intervalCount,
+        }),
+      });
+    } catch (err) {
+      console.error(err);
+      throw new InternalServerError(`Elasticsearch: ${err.message}`);
+    }
 
+    // Get allowed roster data for the individuals returned from ES.
     let rosterEntries: Roster[];
     if (unitId) {
       rosterEntries = await Roster.find({
@@ -39,193 +69,179 @@ export const musterUtils = {
       });
     }
 
+    const rosterEntriesByEdipi: { [edipi: string]: Roster } = {};
+    rosterEntries.forEach(e => {
+      rosterEntriesByEdipi[e.edipi] = e;
+    });
+
     const allowedRosterColumns = await Roster.getAllowedColumns(org, role);
 
-    // Calculate each individual's max reports for this time range.
-    const maxReportsByEdipi = {} as { [edipi: string]: number };
-    const timeRange = {
-      startDate: moment().startOf('day').subtract(intervalCount, 'days'),
-      endDate: moment().startOf('day'),
+    const aggs = response.aggregations as {
+      muster: {
+        buckets: Array<{
+          key: {
+            edipi: string
+            reported: boolean
+          }
+          doc_count: number
+        }>
+      }
     };
 
-    for (const entry of rosterEntries) {
-      let startDate = moment(entry.startDate ?? timeRange.startDate).startOf('day');
-      if (startDate < timeRange.startDate) {
-        startDate = timeRange.startDate;
+    // Collect reports and reports missed.
+    const individualStats: IndividualStats = {};
+
+    for (const bucket of aggs.muster.buckets) {
+      const { edipi, reported } = bucket.key;
+
+      if (!individualStats[edipi]) {
+        individualStats[edipi] = {
+          mustersReported: 0,
+          mustersNotReported: 0,
+          nonMusterPercent: 0,
+        };
       }
 
-      let endDate = moment(entry.endDate ?? timeRange.endDate).startOf('day');
-      if (endDate > timeRange.endDate) {
-        endDate = timeRange.endDate;
+      if (reported) {
+        individualStats[edipi].mustersReported = bucket.doc_count;
+      } else {
+        individualStats[edipi].mustersNotReported = bucket.doc_count;
       }
-
-      maxReportsByEdipi[entry.edipi] = endDate.diff(startDate, 'days');
-    }
-
-    // Send request.
-    let response: SearchResponse<unknown>;
-    try {
-      response = await elasticsearch.search({
-        index: role.getKibanaIndexForMuster(unitId),
-        body: {
-          size: 0,
-          query: {
-            bool: {
-              filter: [{
-                range: {
-                  Timestamp: {
-                    gte: timeRange.startDate.format(musterUtils.dateFormat),
-                    lt: timeRange.endDate.format(musterUtils.dateFormat),
-                  },
-                },
-              }],
-            },
-          },
-          aggs: {
-            reportsByPerson: {
-              terms: {
-                size: 10000,
-                field: 'Roster.edipi.keyword',
-              },
-            },
-          },
-        },
-      });
-    } catch (err) {
-      throw new InternalServerError(`Elasticsearch: ${err.message}`);
-    }
-
-    const reportsByPersonBuckets = (response.aggregations ? response.aggregations.reportsByPerson.buckets : []) as {
-      key: string
-      doc_count: number
-    }[];
-
-    const esReportsByEdipi = {} as { [edipi: string]: number };
-    for (const bucket of reportsByPersonBuckets) {
-      esReportsByEdipi[bucket.key] = bucket.doc_count;
     }
 
     // Calculate non-muster percents.
-    const individuals = [] as MusterIndividual[];
-    for (const rosterEntry of (rosterEntries as MusterIndividual[])) {
-      const reports = esReportsByEdipi[rosterEntry.edipi] ?? 0;
-      const maxReports = maxReportsByEdipi[rosterEntry.edipi];
-      const nonMusterPercent = musterUtils.calcNonMusterPercent(reports, maxReports);
-      if (nonMusterPercent > 0) {
-        const individual = rosterEntry as MusterIndividual;
-        individual.nonMusterPercent = nonMusterPercent;
-        individuals.push(individual);
-      }
+    for (const edipi of Object.keys(individualStats)) {
+      const data = individualStats[edipi];
+      individualStats[edipi].nonMusterPercent = musterUtils.calcNonMusterPercent(data.mustersReported, data.mustersNotReported);
     }
 
-    individuals.sort((a, b) => {
-      let diff = b.nonMusterPercent - a.nonMusterPercent;
-      if (diff !== 0) {
+    // Build a sorted array of the individuals' stats merged with their roster data.
+    const individuals = Object.keys(individualStats)
+      .filter(edipi => {
+        return (
+          rosterEntriesByEdipi[edipi]
+          && individualStats[edipi].nonMusterPercent > 0
+        );
+      })
+      .sort((edipiA, edipiB) => {
+        const entryA = rosterEntriesByEdipi[edipiA];
+        const entryB = rosterEntriesByEdipi[edipiB];
+        const individualA = individualStats[edipiA];
+        const individualB = individualStats[edipiB];
+
+        let diff = individualB.nonMusterPercent - individualA.nonMusterPercent;
+        if (diff === 0) {
+          diff = entryA.unit?.name.localeCompare(entryB.unit!.name) ?? 0;
+        }
+        if (diff === 0) {
+          diff = entryA.lastName?.localeCompare(entryB.lastName!) ?? 0;
+        }
+        if (diff === 0) {
+          diff = entryA.firstName?.localeCompare(entryB.firstName!) ?? 0;
+        }
         return diff;
-      }
+      })
+      .map(edipi => {
+        const rosterEntryCleaned: Partial<Roster> = {};
+        const rosterEntry = rosterEntriesByEdipi[edipi];
+        const individual = individualStats[edipi];
+        for (const columnInfo of allowedRosterColumns) {
+          const columnValue = rosterEntry.getColumnValue(columnInfo);
+          Reflect.set(rosterEntryCleaned, columnInfo.name, columnValue);
+        }
+        return {
+          ...individual,
+          ...rosterEntryCleaned,
+          unitId: rosterEntry.unit.id,
+        } as IndividualStats[string] & Partial<Roster>;
+      });
 
-      diff = a.unit.name.localeCompare(b.unit.name);
-      if (diff !== 0) {
-        return diff;
-      }
-
-      diff = a.lastName.localeCompare(b.lastName);
-      if (diff !== 0) {
-        return diff;
-      }
-
-      return a.firstName.localeCompare(b.firstName);
-    });
-
-    // Only return data the user has permissions for.
-    return individuals.map(individual => {
-      const individualCleaned = {} as MusterIndividual;
-      for (const columnInfo of allowedRosterColumns) {
-        const columnValue = individual.getColumnValue(columnInfo);
-        Reflect.set(individualCleaned, columnInfo.name, columnValue);
-      }
-      individualCleaned.id = individual.id;
-      individualCleaned.unitId = individual.unit.id;
-      individualCleaned.nonMusterPercent = individual.nonMusterPercent;
-      return individualCleaned;
-    });
+    return individuals;
   },
 
-  async getUnitRosterCounts(role: Role, interval: 'week' | 'month', intervalCount: number) {
-    const momentUnitOfTime = {
-      week: 'isoWeek',
-      month: 'month',
-    }[interval] as unitOfTime.StartOf;
+  /**
+   * Get aggregated unit muster stats over the given weeks/months.
+   */
+  async getUnitMusterStats(args: {
+    role: Role
+    weeksCount: number
+    monthsCount: number
+  }) {
+    const { role, weeksCount, monthsCount } = args;
 
-    const params = [] as any[];
-    const orgIdParamIndex = addParam(params, role.org!.id);
-    const unitFilter = role.getUnitFilter().replace('*', '%');
-    const unitFilterParamIndex = addParam(params, unitFilter);
+    // Get unit names.
+    const unitIdFilter = role.getUnitFilter().replace('*', '%');
+    const units = await Unit.find({
+      where: {
+        org: role.org,
+        id: Like(unitIdFilter),
+      },
+    });
 
-    // Query the number of individuals grouped by unit who were active between the start/end dates.
-    // NOTE: There may be a more efficient way of doing this where we don't require a union of multiple queries, but this
-    // should work well enough as long as the interval count isn't too high.
-    const queries = [] as string[];
-    const dates = new Set<string>();
-    for (let i = 0; i < intervalCount; i++) {
-      const startDate = moment.utc().subtract(i + 1, interval).startOf(momentUnitOfTime).format(musterUtils.dateFormat);
-      const endDate = moment.utc(startDate).add(1, interval).format(musterUtils.dateFormat);
-      const startDateParamIndex = addParam(params, startDate);
-      const endDateParamIndex = addParam(params, endDate);
-      queries.push(`
-        SELECT unit_id as "unitId", count(id), $${startDateParamIndex}::varchar as date
-        FROM roster
-        WHERE
-          unit_org = $${orgIdParamIndex} AND
-          unit_id LIKE $${unitFilterParamIndex} AND
-          (start_date IS null AND (end_date IS null OR end_date > $${endDateParamIndex}::date))
-          OR (start_date <= $${startDateParamIndex}::date AND (end_date IS null OR end_date > $${endDateParamIndex}::date))
-        GROUP BY "unitId"
-      `);
+    const unitNames = units.map(u => u.name);
 
-      dates.add(startDate);
+    //
+    // Build elastcisearch multisearch queries.
+    //
+    const index = role.getKibanaIndexForMuster();
+    const esBody = [
+      { index },
+      buildMusterEsBody({
+        interval: 'week',
+        intervalCount: weeksCount,
+      }),
+
+      { index },
+      buildMusterEsBody({
+        interval: 'month',
+        intervalCount: monthsCount,
+      }),
+    ] as any[];
+
+    // Send ES request.
+    let response: MSearchResponse<unknown>;
+    try {
+      response = await elasticsearch.msearch({ body: esBody });
+    } catch (err) {
+      console.error(err);
+      throw new InternalServerError(`Elasticsearch: ${err.message}`);
     }
 
-    const rows = await getConnection().query(queries.join(`UNION`), params) as {
-      unitId: string
-      date: string
-      count: string
-    }[];
+    //
+    // Organize and return data.
+    //
+    const weeklyAggs = response.responses![0].aggregations as MusterAggregation;
+    const monthlyAggs = response.responses![1].aggregations as MusterAggregation;
 
-    const unitRosterCountByDate = {} as {
-      [date: string]: {
-        [unitId: string]: number
-      }
+    return {
+      weekly: buildUnitStats({
+        aggregations: weeklyAggs,
+        unitNames,
+        interval: 'week',
+        intervalCount: weeksCount,
+      }),
+      monthly: buildUnitStats({
+        aggregations: monthlyAggs,
+        unitNames,
+        interval: 'month',
+        intervalCount: monthsCount,
+      }),
     };
-
-    // Make sure all of the dates have entries, even if the query didn't return any data for some.
-    for (const date of dates) {
-      if (!unitRosterCountByDate[date]) {
-        unitRosterCountByDate[date] = {};
-      }
-    }
-
-    for (const row of rows) {
-      const date = row.date;
-      const unitId = row.unitId;
-
-      if (!unitRosterCountByDate[date][unitId]) {
-        unitRosterCountByDate[date][unitId] = 0;
-      }
-
-      unitRosterCountByDate[date][unitId] += parseInt(row.count);
-    }
-
-    return unitRosterCountByDate;
   },
 
-  calcNonMusterPercent(reports: number, maxReports: number) {
-    if (maxReports === 0) {
+  calcNonMusterPercent(mustersReported: number, mustersNotReported: number) {
+    const totalReports = mustersReported + mustersNotReported;
+    if (totalReports === 0) {
       return 0;
     }
 
-    const nonMusterRatio = 1 - (reports / maxReports);
-    return Math.min(Math.max(nonMusterRatio, 0), 1) * 100;
+    const nonMusterPercent = (mustersNotReported / totalReports) * 100;
+
+    if (nonMusterPercent < 0 || nonMusterPercent > 100) {
+      console.warn(`Invalid non-muster percent (${nonMusterPercent}). It should be between 0 and 100.`);
+    }
+
+    return nonMusterPercent;
   },
 
   getEarliestMusterWindowTime(muster: MusterConfiguration, referenceTime: number) {
@@ -265,15 +281,207 @@ export const musterUtils = {
 
 };
 
-function addParam(params: any[], data: any) {
-  params.push(data);
-  return params.length;
+function buildIndividualsMusterBody({
+  interval,
+  intervalCount,
+}: {
+  interval: TimeInterval,
+  intervalCount: number
+}) {
+  const esInterval = getEsTimeInterval(interval);
+
+  return {
+    size: 0,
+    query: {
+      bool: {
+        filter: [
+          {
+            range: {
+              Timestamp: {
+                gte: `now-${intervalCount}${esInterval}/${esInterval}`,
+                lte: `now/${esInterval}`,
+              },
+            },
+          },
+        ],
+      },
+    },
+    aggs: {
+      muster: {
+        composite: {
+          size: 10000,
+          sources: [
+            {
+              edipi: {
+                terms: {
+                  field: 'Roster.edipi.keyword',
+                },
+              },
+            },
+            {
+              reported: {
+                terms: {
+                  field: 'Muster.reported',
+                  missing_bucket: true,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
 }
 
-export type MusterIndividual = {
-  nonMusterPercent: number
-  unitId: string
-} & Roster;
+function buildMusterEsBody({
+  interval,
+  intervalCount,
+}: {
+  interval: TimeInterval,
+  intervalCount: number
+}) {
+  const esInterval = getEsTimeInterval(interval);
+
+  return {
+    size: 0,
+    query: {
+      bool: {
+        filter: [
+          {
+            range: {
+              Timestamp: {
+                gte: `now-${intervalCount}${esInterval}/${esInterval}`,
+                lt: `now/${esInterval}`,
+              },
+            },
+          },
+        ],
+      },
+    },
+    aggs: {
+      muster: {
+        composite: {
+          size: 10000,
+          sources: [
+            {
+              date: {
+                date_histogram: {
+                  field: 'Timestamp',
+                  interval: `1${esInterval}`,
+                  format: getEsDateFormat(interval),
+                },
+              },
+            },
+            {
+              unit: {
+                terms: {
+                  field: 'Roster.unit.keyword',
+                },
+              },
+            },
+            {
+              reported: {
+                terms: {
+                  field: 'Muster.reported',
+                  missing_bucket: true,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function buildUnitStats(args: {
+  aggregations: MusterAggregation,
+  unitNames: string[]
+  interval: TimeInterval
+  intervalCount: number
+}) {
+  const { aggregations, unitNames, interval, intervalCount } = args;
+
+  // For week intervals, start on Mondays like ES does.
+  const momentStartOf = (interval === 'week') ? 'isoWeek' : interval;
+
+  // Initialize unit stats. Use our own set of dates and unit names, since ES may be missing some due to composite
+  // aggregations not being able to return empty buckets.
+  const unitStats = {} as UnitStatsByDate;
+  for (let i = 0; i < intervalCount; i++) {
+    const dateStr = moment.utc()
+      .subtract(i + 1, interval)
+      .startOf(momentStartOf)
+      .format(getMomentDateFormat(interval));
+
+    unitStats[dateStr] = {};
+    for (const unitName of unitNames) {
+      unitStats[dateStr][unitName] = {
+        mustersReported: 0,
+        mustersNotReported: 0,
+        nonMusterPercent: 0,
+      };
+    }
+  }
+
+  // Collect reports and reports missed.
+  for (const bucket of aggregations.muster.buckets) {
+    const { date, unit, reported } = bucket.key;
+
+    if (unitStats[date][unit] == null) {
+      // Unit was in aggregation but not in the sql database, so skip it.
+      continue;
+    }
+
+    if (reported) {
+      unitStats[date][unit].mustersReported = bucket.doc_count;
+    } else {
+      unitStats[date][unit].mustersNotReported = bucket.doc_count;
+    }
+  }
+
+  // Calculate non-muster percents.
+  for (const date of Object.keys(unitStats)) {
+    for (const unit of Object.keys(unitStats[date])) {
+      const data = unitStats[date][unit];
+      unitStats[date][unit].nonMusterPercent = musterUtils.calcNonMusterPercent(data.mustersReported, data.mustersNotReported);
+    }
+  }
+
+  return unitStats;
+}
+
+type IndividualStats = {
+  [edipi: string]: {
+    mustersReported: number
+    mustersNotReported: number
+    nonMusterPercent: number
+    unitId?: string
+  }
+};
+
+type UnitStatsByDate = {
+  [date: string]: {
+    [unitName: string]: {
+      mustersReported: number
+      mustersNotReported: number
+      nonMusterPercent: number
+    }
+  }
+};
+
+type MusterAggregation = {
+  muster: {
+    buckets: {
+      key: {
+        date: string
+        unit: string
+        reported: boolean
+      }
+      doc_count: number
+    }[]
+  }
+};
 
 export interface MusterWindow {
   id: string,

--- a/server/util/util.ts
+++ b/server/util/util.ts
@@ -119,7 +119,7 @@ export type TimeInterval =
   | 'month'
   | 'year';
 
-export function getEsTimeInterval(interval: TimeInterval) {
+export function getElasticsearchTimeInterval(interval: TimeInterval) {
   switch (interval) {
     case 'day': return 'd';
     case 'week': return 'w';
@@ -130,7 +130,7 @@ export function getEsTimeInterval(interval: TimeInterval) {
   }
 }
 
-export function getEsDateFormat(interval: TimeInterval) {
+export function getElasticsearchDateFormat(interval: TimeInterval) {
   switch (interval) {
     case 'day':
     case 'week': return 'yyyy-MM-dd';
@@ -152,25 +152,18 @@ export function getMomentDateFormat(interval: TimeInterval) {
   }
 }
 
-export function requireQuery<TQuery extends object>(
+export function assertRequestQuery<TQuery extends object>(
   req: ApiRequest<unknown, unknown, TQuery>,
-  keys: Array<keyof TQuery>,
+  requiredKeys: Array<keyof TQuery>,
 ) {
-  const missing = getMissingKeys(req.query, keys);
-  if (missing.length) {
-    throw new BadRequestError(`Missing required query params: ${missing.join(', ')}`);
+  const missingKeys = getMissingKeys(req.query, requiredKeys);
+  if (missingKeys.length) {
+    throw new BadRequestError(`Missing required request query params: ${missingKeys.join(', ')}`);
   }
 
   return req.query;
 }
 
 function getMissingKeys<T extends object>(obj: T, keys: Array<keyof T>) {
-  const missing = [];
-  for (const key of keys) {
-    if (obj[key] === undefined) {
-      missing.push(key);
-    }
-  }
-
-  return missing;
+  return keys.filter(key => obj[key] === undefined);
 }

--- a/src/components/pages/muster-page/muster-page.tsx
+++ b/src/components/pages/muster-page/muster-page.tsx
@@ -175,7 +175,12 @@ export const MusterPage = () => {
 
   const reloadTrendData = useCallback(async () => {
     try {
-      const data = (await axios.get(`api/muster/${orgId}/trends`)).data as ApiMusterTrends;
+      const data = (await axios.get(`api/muster/${orgId}/trends`, {
+        params: {
+          weeksCount: 6,
+          monthsCount: 6,
+        },
+      })).data as ApiMusterTrends;
       setRawTrendData(data);
     } catch (error) {
       showErrorDialog('Get Trends', error);
@@ -233,11 +238,11 @@ export const MusterPage = () => {
         x: datesSorted,
         y: [] as number[],
         name: name || unitId,
-        hovertemplate: `%{y:.2f}%`,
+        hovertemplate: `%{y:.1f}%`,
       };
 
       for (const date of datesSorted) {
-        const nonMusterPercent = unitStatsByDate[date][unitId]?.nonMusterPercent ?? 0;
+        const nonMusterPercent = unitStatsByDate[date][unitId].nonMusterPercent;
         chartData.y.push(nonMusterPercent);
       }
 

--- a/src/models/api-response.ts
+++ b/src/models/api-response.ts
@@ -157,9 +157,9 @@ export interface ApiWorkspace {
 export interface ApiUnitStatsByDate {
   [date: string]: {
     [unitName: string]: {
+      mustersReported: number
+      mustersNotReported: number
       nonMusterPercent: number
-      reportsCount: number
-      rosterCount: number
     }
   }
 }


### PR DESCRIPTION
The Muster page should work just as it did before with no apparent change. However, the backend has been completely reworked to use a much simpler and scalable approach leveraging the `Muster.reported` field that now exists in Elasticsearch.

Here are some other things I added or changed that may be worth noting...

- Added a unique index to the Unit model on the `org` and `name` fields, since an org should never have two different units with the exact same name.
- Modified the `object-curly-newline` eslint rule since it was excessively strict, forcing object destructuring with multiple fields to be broken into multiple lines. Now it will just enforce consistency so that, for any particular destructuring operation, you either put all of the fields on one line, or all on their own line.
- Added a `migration-revert.sh` script to be able to easily run the `down` function in the last applied migration. This is really useful in development.
- Added a `requireQuery` function that can be used to easily validate that query fields are set. If any of the listed fields aren't set, it'll throw an error listing them. I opted not to make it a middleware function, because I think it's better to have that validation right where you're working in the actual endpoint function.
  
  The `requireQuery` function also returns the query object, so you can destructure all of the variables you need at the same time if they don't require any more processing (such as `parseInt`).

  We should add something similar for validating the request body as well, but I didn't really want to add an unused function. We can add it next time we need to validate some body data.