### PR TITLE
Page help

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,6 +71,7 @@
     "react/destructuring-assignment": "off",
     "react/jsx-one-expression-per-line": "off",
     "react/jsx-props-no-spreading": "off",
+    "react/no-array-index-key": "off",
     "react/require-default-props": "off",
     "react-hooks/exhaustive-deps": "error",
     "space-before-function-paren": ["error", {

--- a/src/actions/help-card.actions.ts
+++ b/src/actions/help-card.actions.ts
@@ -1,0 +1,21 @@
+import { Dispatch } from 'redux';
+
+export namespace HelpCard {
+
+  export namespace Actions {
+
+    export class Hide {
+      static type = 'HELP_TEXT_HIDE';
+      type = Hide.type;
+      constructor(public payload: {
+        helpCardId: string
+      }) {}
+    }
+
+  }
+
+  export const hide = (helpCardId: string) => (dispatch: Dispatch<Actions.Hide>) => {
+    dispatch(new Actions.Hide({ helpCardId }));
+  };
+
+}

--- a/src/components/app-sidenav/app-sidenav.styles.ts
+++ b/src/components/app-sidenav/app-sidenav.styles.ts
@@ -16,7 +16,7 @@ export default makeStyles((theme: Theme) => createStyles({
   expander: {
     position: 'fixed',
     top: '79px',
-    zIndex: 10000,
+    zIndex: theme.zIndex.drawer + 1,
     left: sidenavWidthExpanded - expanderRadius - 5,
     backgroundColor: theme.palette.background.default,
     width: expanderRadius + 5,

--- a/src/components/help/help-button/help-button.tsx
+++ b/src/components/help/help-button/help-button.tsx
@@ -1,0 +1,55 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+} from '@material-ui/core';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import React, {
+  ElementType,
+  ReactNode,
+  useState,
+} from 'react';
+import { HelpContent } from '../help-content/help-content';
+
+export interface HelpButtonProps {
+  title: string
+  contentComponent: ElementType
+  children?: ReactNode
+}
+
+export const HelpButton = (props: HelpButtonProps) => {
+  const { title, contentComponent: ContentComponent, children } = props;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <IconButton onClick={() => setOpen(true)}>
+        {children}
+        {!children && (
+          <InfoOutlinedIcon />
+        )}
+      </IconButton>
+
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>
+          {title}
+        </DialogTitle>
+
+        <DialogContent>
+          <HelpContent>
+            <ContentComponent />
+          </HelpContent>
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>
+            Ok
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/src/components/help/help-card/help-card.styles.ts
+++ b/src/components/help/help-card/help-card.styles.ts
@@ -1,0 +1,19 @@
+import { Theme } from '@material-ui/core/styles';
+import {
+  makeStyles,
+  createStyles,
+} from '@material-ui/styles';
+
+export default makeStyles((theme: Theme) => createStyles({
+  card: {
+    backgroundColor: '#ECF4FC',
+    marginBottom: theme.spacing(3),
+  },
+  cardContent: {
+    paddingTop: theme.spacing(3),
+    paddingBottom: theme.spacing(2),
+  },
+  cardActions: {
+    paddingTop: 0,
+  },
+}));

--- a/src/components/help/help-card/help-card.tsx
+++ b/src/components/help/help-card/help-card.tsx
@@ -1,0 +1,49 @@
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+} from '@material-ui/core';
+import React, { ReactNode } from 'react';
+import {
+  useDispatch,
+  useSelector,
+} from 'react-redux';
+import { HelpCard as HelpCardActions } from '../../../actions/help-card.actions';
+import { AppState } from '../../../store';
+import { HelpContent } from '../help-content/help-content';
+import useStyles from './help-card.styles';
+
+export interface HelpCardProps {
+  helpCardId: string
+  children?: ReactNode
+}
+
+export const HelpCard = (props: HelpCardProps) => {
+  const { helpCardId, children } = props;
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const hide = useSelector<AppState, boolean>(state => state.localStorage.hideHelpCard?.[helpCardId] ?? false);
+
+  const handleGotItClick = () => {
+    dispatch(HelpCardActions.hide(helpCardId));
+  };
+
+  if (hide) {
+    return null;
+  }
+
+  return (
+    <Card className={classes.card}>
+      <CardContent className={classes.cardContent}>
+        <HelpContent>
+          {children}
+        </HelpContent>
+      </CardContent>
+
+      <CardActions className={classes.cardActions}>
+        <Button onClick={handleGotItClick}>Ok, I got it</Button>
+      </CardActions>
+    </Card>
+  );
+};

--- a/src/components/help/help-content/help-content.styles.ts
+++ b/src/components/help/help-content/help-content.styles.ts
@@ -1,0 +1,20 @@
+import { Theme } from '@material-ui/core/styles';
+import {
+  makeStyles,
+  createStyles,
+} from '@material-ui/styles';
+
+export default makeStyles((theme: Theme) => createStyles({
+  root: {
+    fontSize: '16px',
+    lineHeight: '28px',
+
+    '& > *:not(:last-child)': {
+      marginBottom: theme.spacing(2),
+    },
+
+    '& li:not(:last-child)': {
+      paddingBottom: theme.spacing(1),
+    },
+  },
+}));

--- a/src/components/help/help-content/help-content.tsx
+++ b/src/components/help/help-content/help-content.tsx
@@ -1,0 +1,18 @@
+import { Box } from '@material-ui/core';
+import React, { ReactNode } from 'react';
+import useStyles from './help-content.styles';
+
+export interface HelpContentProps {
+  children?: ReactNode
+}
+
+export const HelpContent = (props: HelpContentProps) => {
+  const { children } = props;
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.root}>
+      {children}
+    </Box>
+  );
+};

--- a/src/components/page-header/page-header.styles.ts
+++ b/src/components/page-header/page-header.styles.ts
@@ -1,4 +1,7 @@
-import { Theme, createStyles } from '@material-ui/core';
+import {
+  Theme,
+  createStyles,
+} from '@material-ui/core';
 import { makeStyles } from '@material-ui/styles';
 
 export default makeStyles((theme: Theme) => createStyles({
@@ -13,6 +16,9 @@ export default makeStyles((theme: Theme) => createStyles({
   },
   info: {
     color: theme.palette.text.hint,
+    marginTop: theme.spacing(2),
+  },
+  helpCardContainer: {
     marginTop: theme.spacing(2),
   },
 }));

--- a/src/components/page-header/page-header.tsx
+++ b/src/components/page-header/page-header.tsx
@@ -1,20 +1,46 @@
-import React from 'react';
-import { Typography } from '@material-ui/core';
+import React, { ElementType } from 'react';
+import {
+  Box,
+  Typography,
+} from '@material-ui/core';
+import { HelpButton } from '../help/help-button/help-button';
+import { HelpCard } from '../help/help-card/help-card';
 import useStyles from './page-header.styles';
 
 export interface PageHeaderProps {
   title: string
-  info?: string
+  help?: {
+    contentComponent: ElementType
+    cardId: string
+  }
 }
 
-const PageHeader = ({ title, info }: PageHeaderProps) => {
+const PageHeader = (props: PageHeaderProps) => {
+  const { title, help } = props;
+  const HelpContent = help?.contentComponent;
   const classes = useStyles();
 
   return (
     <header className={classes.header}>
-      <Typography className={classes.title}>{title}</Typography>
-      {info && (
-        <Typography className={classes.info}>{info}</Typography>
+      <Box display="flex" alignItems="center">
+        <Typography className={classes.title}>
+          {title}
+        </Typography>
+
+        {help && (
+          <HelpButton
+            title={title}
+            contentComponent={help.contentComponent}
+          />
+        )}
+      </Box>
+
+      {(help && HelpContent) && (
+        <Box className={classes.helpCardContainer}>
+          <HelpCard helpCardId={help.cardId}>
+            <HelpContent />
+          </HelpCard>
+        </Box>
       )}
     </header>
   );

--- a/src/components/page-help/page-help.tsx
+++ b/src/components/page-help/page-help.tsx
@@ -1,0 +1,33 @@
+import { Box } from '@material-ui/core';
+import React, { ReactNode } from 'react';
+
+export type PageHelpProps = {
+  description: string | ReactNode
+  bullets?: Array<string | ReactNode>
+};
+
+export const PageHelp = (props: PageHelpProps) => {
+  const { description, bullets } = props;
+
+  return (
+    <>
+      <Box>
+        {description}
+      </Box>
+
+      {bullets && (
+        <>
+          <Box fontWeight="bold">
+            With this view you can:
+          </Box>
+
+          <Box>
+            <ul>
+              {bullets.map(text => <li>{text}</li>)}
+            </ul>
+          </Box>
+        </>
+      )}
+    </>
+  );
+};

--- a/src/components/pages/data-export-page/data-export-page-help.tsx
+++ b/src/components/pages/data-export-page/data-export-page-help.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { PageHelp } from '../../page-help/page-help';
+
+export const DataExportPageHelp = () => {
+  return (
+    <PageHelp
+      description={`
+        Quickly generate a single CSV file that contains all of your group's report data for a specified time range.
+      `}
+    />
+  );
+};

--- a/src/components/pages/data-export-page/data-export-page.tsx
+++ b/src/components/pages/data-export-page/data-export-page.tsx
@@ -24,6 +24,7 @@ import { getLineCount } from '../../../utility/string-utils';
 import { ButtonWithSpinner } from '../../buttons/button-with-spinner';
 import { LinearProgressWithPercent } from '../../linear-progress-with-label/linear-progress-with-label';
 import PageHeader from '../../page-header/page-header';
+import { DataExportPageHelp } from './data-export-page-help';
 import useStyles from './data-export-page.styles';
 
 export const DataExportPage = () => {
@@ -109,7 +110,10 @@ export const DataExportPage = () => {
       <Container maxWidth="md">
         <PageHeader
           title="Data Export"
-          info="Export your group data quickly and easily."
+          help={{
+            contentComponent: DataExportPageHelp,
+            cardId: 'dataExportPage',
+          }}
         />
 
         <Grid container spacing={3}>

--- a/src/components/pages/home-page/home-page.tsx
+++ b/src/components/pages/home-page/home-page.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import {
-  Card, CardContent, Container, Grid, Typography,
+  Card,
+  CardContent,
+  Container,
+  Grid,
+  Typography,
 } from '@material-ui/core';
 import { UserSelector } from '../../../selectors/user.selector';
 import { Link } from '../../link/link';

--- a/src/components/pages/muster-page/muster-page-help.tsx
+++ b/src/components/pages/muster-page/muster-page-help.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { PageHelp } from '../../page-help/page-help';
+
+export const MusterPageHelp = () => {
+  return (
+    <PageHelp
+      description={`
+        This view highlights individuals and units who have a higher than normal Non-muster Rate per their established
+        muster requirements. The table displays the individuals, while the two graphs (below) show offending units by
+        weekly and monthly trends.
+      `}
+      bullets={[
+        'Identify individuals who have a high Non-muster Rate',
+        'Identify units that have a high Non-muster Rate',
+        'Export a CSV file containing all non-compliant individuals&apos; muster data',
+      ]}
+    />
+  );
+};

--- a/src/components/pages/muster-page/muster-page.tsx
+++ b/src/components/pages/muster-page/muster-page.tsx
@@ -30,6 +30,7 @@ import { getMaxPageIndex, getNewPageIndex, columnInfosOrdered } from '../../../u
 import PageHeader from '../../page-header/page-header';
 import { TableCustomColumnsContent } from '../../tables/table-custom-columns-content';
 import { TablePagination } from '../../tables/table-pagination/table-pagination';
+import { MusterPageHelp } from './muster-page-help';
 import useStyles from './muster-page.styles';
 import { UserState } from '../../../reducers/user.reducer';
 import { AppState } from '../../../store';
@@ -379,7 +380,13 @@ export const MusterPage = () => {
   return (
     <main className={classes.root}>
       <Container maxWidth="md">
-        <PageHeader title="Muster Non-Compliance" />
+        <PageHeader
+          title="Muster Non-Compliance"
+          help={{
+            contentComponent: MusterPageHelp,
+            cardId: 'musterPage',
+          }}
+        />
 
         <Grid container spacing={3}>
           {/* Table */}

--- a/src/components/pages/role-management-page/role-management-page-help.tsx
+++ b/src/components/pages/role-management-page/role-management-page-help.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PageHelp } from '../../page-help/page-help';
+
+export const RoleManagementPageHelp = () => {
+  return (
+    <PageHelp
+      description={`
+        Every user in StatusEngine is assigned a role when accepted to a group. A role defines access to specific
+        units, workspaces, notifications, certain roster information, and other management permissions.
+      `}
+      bullets={[
+        'Add, Edit, or Delete roles',
+        'Edit role metadata: Role Name, Description, Workspace Access, Unit Access, Allowed Notifications, and Role Permissions',
+      ]}
+    />
+  );
+};

--- a/src/components/pages/role-management-page/role-management-page.tsx
+++ b/src/components/pages/role-management-page/role-management-page.tsx
@@ -13,6 +13,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import axios from 'axios';
 import PageHeader from '../../page-header/page-header';
+import { RoleManagementPageHelp } from './role-management-page-help';
 import useStyles from './role-management-page.styles';
 import { EditRoleDialog, EditRoleDialogProps } from './edit-role-dialog';
 import { AppFrame } from '../../../actions/app-frame.actions';
@@ -101,7 +102,13 @@ export const RoleManagementPage = () => {
   return (
     <main className={classes.root}>
       <Container maxWidth="md">
-        <PageHeader title="Group Roles" />
+        <PageHeader
+          title="Group Roles"
+          help={{
+            contentComponent: RoleManagementPageHelp,
+            cardId: 'roleManagementPage',
+          }}
+        />
         <ButtonSet>
           <Button
             size="large"

--- a/src/components/pages/roster-columns-page/roster-columns-page-help.tsx
+++ b/src/components/pages/roster-columns-page/roster-columns-page-help.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PageHelp } from '../../page-help/page-help';
+
+export const RosterColumnsPageHelp = () => {
+  return (
+    <PageHelp
+      description={`
+        Create and manage custom columns that appear on your group’s roster.
+      `}
+      bullets={[
+        'Add, Edit, or Delete custom columns',
+        'Edit a custom column’s display name',
+        'Edit custom column flags (e.g. Contains PII, Required, Multiline, etc.)',
+      ]}
+    />
+  );
+};

--- a/src/components/pages/roster-columns-page/roster-columns-page.tsx
+++ b/src/components/pages/roster-columns-page/roster-columns-page.tsx
@@ -17,12 +17,19 @@ import {
   TableHead,
   TableRow,
 } from '@material-ui/core';
-import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, {
+  useEffect,
+  useState,
+} from 'react';
+import {
+  useDispatch,
+  useSelector,
+} from 'react-redux';
 import axios from 'axios';
 import AddCircleIcon from '@material-ui/icons/AddCircle';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import PageHeader from '../../page-header/page-header';
+import { RosterColumnsPageHelp } from './roster-columns-page-help';
 import useStyles from './roster-columns-page.styles';
 import { ApiRosterColumnInfo, rosterColumnTypeDisplayName } from '../../../models/api-response';
 import { EditColumnDialog, EditColumnDialogProps } from './edit-column-dialog';
@@ -127,7 +134,13 @@ export const RosterColumnsPage = () => {
   return (
     <main className={classes.root}>
       <Container maxWidth="md">
-        <PageHeader title="Custom Roster Columns" />
+        <PageHeader
+          title="Custom Roster Columns"
+          help={{
+            contentComponent: RosterColumnsPageHelp,
+            cardId: 'rosterColumnsPage',
+          }}
+        />
         <ButtonSet>
           <Button
             size="large"

--- a/src/components/pages/roster-page/roster-page-help.tsx
+++ b/src/components/pages/roster-page/roster-page-help.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { PageHelp } from '../../page-help/page-help';
+
+export const RosterPageHelp = () => {
+  return (
+    <PageHelp
+      description={`
+        The roster is simply the list of individuals within your group. By default, StatusEngine displays the following
+        columns: EDIPI, First Name, Last Name, Unit, and Last Reported. Additional custom columns may be added by
+        visiting the Roster Columns view.
+      `}
+      bullets={[
+        'Upload a CSV file to append entries to the existing roster',
+        'Download a CSV template containing all roster columns (including custom columns) ',
+        'Export all your group’s roster data to a CSV file',
+        'Add, Edit, or Delete individual roster entries',
+        'Delete all roster entries',
+        'Filter the roster by any number of columns and combinations',
+        'Show or hide columns',
+      ]}
+    />
+  );
+};

--- a/src/components/pages/roster-page/roster-page.tsx
+++ b/src/components/pages/roster-page/roster-page.tsx
@@ -33,6 +33,7 @@ import { getNewPageIndex } from '../../../utility/table';
 import PageHeader from '../../page-header/page-header';
 import { SortDirection, TableColumn, TableCustomColumnsContent } from '../../tables/table-custom-columns-content';
 import { TablePagination } from '../../tables/table-pagination/table-pagination';
+import { RosterPageHelp } from './roster-page-help';
 import useStyles from './roster-page.styles';
 import {
   ApiRosterColumnInfo,
@@ -386,7 +387,13 @@ export const RosterPage = () => {
   return (
     <main className={classes.root}>
       <Container maxWidth={false}>
-        <PageHeader title="Roster" />
+        <PageHeader
+          title="Roster"
+          help={{
+            contentComponent: RosterPageHelp,
+            cardId: 'rosterPage',
+          }}
+        />
 
         <ButtonSet>
           <input

--- a/src/components/pages/units-page/units-page-help.tsx
+++ b/src/components/pages/units-page/units-page-help.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PageHelp } from '../../page-help/page-help';
+
+export const UnitsPageHelp = () => {
+  return (
+    <PageHelp
+      description={`
+        This view allows you to easily manage all of the units within your group.
+      `}
+      bullets={[
+        'Add or remove units',
+        'Edit each unit’s muster requirement(s)',
+        'Create group default muster requirement(s)',
+      ]}
+    />
+  );
+};

--- a/src/components/pages/units-page/units-page.tsx
+++ b/src/components/pages/units-page/units-page.tsx
@@ -21,13 +21,20 @@ import {
   TableRow,
   Typography,
 } from '@material-ui/core';
-import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, {
+  useEffect,
+  useState,
+} from 'react';
+import {
+  useDispatch,
+  useSelector,
+} from 'react-redux';
 import moment from 'moment-timezone';
 import axios from 'axios';
 import AddCircleIcon from '@material-ui/icons/AddCircle';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import { UnitsPageHelp } from './units-page-help';
 import useStyles from './units-page.styles';
 import { ApiUnit, MusterConfiguration } from '../../../models/api-response';
 import { EditUnitDialog, EditUnitDialogProps } from './edit-unit-dialog';
@@ -159,7 +166,13 @@ export const UnitsPage = () => {
   return (
     <main className={classes.root}>
       <Container maxWidth="md">
-        <PageHeader title="Unit Management" />
+        <PageHeader
+          title="Unit Management"
+          help={{
+            contentComponent: UnitsPageHelp,
+            cardId: 'unitsPage',
+          }}
+        />
         <Card>
           <CardHeader title="Default Muster Requirements" />
           <CardContent>

--- a/src/components/pages/users-page/users-page-help.tsx
+++ b/src/components/pages/users-page/users-page-help.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { PageHelp } from '../../page-help/page-help';
+
+export const UsersPageHelp = () => {
+  return (
+    <PageHelp
+      description={`
+        This view allows you to manage all users within your group. When a new user requests access to join the group,
+        it will appear in a table labeled “Access Requests” for you to approve or deny the request. If there are no
+        Access Requests, the table will be hidden.
+      `}
+      bullets={[
+        'Change a user’s role within the group',
+        'Delete a user from the group',
+        'View all user access requests (when applicable)',
+        'Approve or Deny user access requests (when applicable)',
+      ]}
+    />
+  );
+};

--- a/src/components/pages/users-page/users-page.tsx
+++ b/src/components/pages/users-page/users-page.tsx
@@ -23,6 +23,7 @@ import MoreVertIcon from '@material-ui/icons/MoreVert';
 import ReportProblemOutlinedIcon from '@material-ui/icons/ReportProblemOutlined';
 import client, { AccessRequestClient, UserClient } from '../../../client';
 import PageHeader from '../../page-header/page-header';
+import { UsersPageHelp } from './users-page-help';
 import useStyles from './users-page.styles';
 import { ApiRole, ApiUser, ApiAccessRequest } from '../../../models/api-response';
 import { AppFrame } from '../../../actions/app-frame.actions';
@@ -193,8 +194,13 @@ export const UsersPage = () => {
   return (
     <main className={classes.root}>
       <Container maxWidth="md">
-        <PageHeader title="Users" />
-
+        <PageHeader
+          title="Users"
+          help={{
+            contentComponent: UsersPageHelp,
+            cardId: 'usersPage',
+          }}
+        />
         {accessRequests.length > 0 && (
           <TableContainer className={classes.table} component={Paper}>
             <Table aria-label="access requests table">

--- a/src/components/pages/workspaces-page/workspaces-page.tsx
+++ b/src/components/pages/workspaces-page/workspaces-page.tsx
@@ -23,6 +23,7 @@ import { ButtonSet } from '../../buttons/button-set';
 import { Modal } from '../../../actions/modal.actions';
 import { formatMessage } from '../../../utility/errors';
 import { UserSelector } from '../../../selectors/user.selector';
+import { WorkspacesPagesHelp } from './workspaces-pages-help';
 
 interface WorkspaceMenuState {
   anchor: HTMLElement | null,
@@ -118,7 +119,13 @@ export const WorkspacesPage = () => {
   return (
     <main className={classes.root}>
       <Container maxWidth="md">
-        <PageHeader title="Workspaces" />
+        <PageHeader
+          title="Workspaces"
+          help={{
+            contentComponent: WorkspacesPagesHelp,
+            cardId: 'workspacesPage',
+          }}
+        />
         <ButtonSet>
           <Button
             size="large"

--- a/src/components/pages/workspaces-page/workspaces-pages-help.tsx
+++ b/src/components/pages/workspaces-page/workspaces-pages-help.tsx
@@ -1,0 +1,43 @@
+import { Tooltip } from '@material-ui/core';
+import React from 'react';
+import { tooltipText } from '../../../utility/tooltip-text';
+import { PageHelp } from '../../page-help/page-help';
+import { TooltipChild } from '../../tooltip-child/tooltip-child';
+
+export const WorkspacesPagesHelp = () => {
+  return (
+    <PageHelp
+      description={(
+        <>
+          A Workspace is a set of dashboards that a user role can access. Dashboards are accessed through the Analytics
+          menu item on the left-hand side menu. StatusEngine currently has three Workspace templates to chose from when
+          creating a Workspace. They correspond to the three levels of data access a user can have
+          (<NonPii />, <Pii />, or <Phi />).
+        </>
+      )}
+      bullets={[
+        'Add, Edit, or Delete workspaces',
+        'Edit a workspace’s name',
+        'Edit a workspace’s description',
+      ]}
+    />
+  );
+};
+
+const NonPii = () => (
+  <Tooltip title={tooltipText.nonPii}>
+    <TooltipChild>Non-PII</TooltipChild>
+  </Tooltip>
+);
+
+const Pii = () => (
+  <Tooltip title={tooltipText.pii}>
+    <TooltipChild>PII</TooltipChild>
+  </Tooltip>
+);
+
+const Phi = () => (
+  <Tooltip title={tooltipText.phi}>
+    <TooltipChild>PHI</TooltipChild>
+  </Tooltip>
+);

--- a/src/components/tooltip-child/tooltip-child.styles.ts
+++ b/src/components/tooltip-child/tooltip-child.styles.ts
@@ -1,0 +1,10 @@
+import { createStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+
+export default makeStyles(() => createStyles({
+  root: {
+    textDecoration: 'underline',
+    textDecorationStyle: 'dotted',
+    cursor: 'help',
+  },
+}));

--- a/src/components/tooltip-child/tooltip-child.tsx
+++ b/src/components/tooltip-child/tooltip-child.tsx
@@ -1,0 +1,27 @@
+import React, {
+  ReactNode,
+  RefObject,
+} from 'react';
+import useStyles from './tooltip-child.styles';
+
+// Material UI doesn't seem to give us any way to automatically style the element that the tooltip is set on,
+// so we need a custom child element to use in order to keep the styling consistent.
+
+export type TooltipItemProps = {
+  children: ReactNode
+};
+
+// https://material-ui.com/components/tooltips/#custom-child-element
+export const TooltipChild = React.forwardRef((props: TooltipItemProps, ref) => {
+  const classes = useStyles();
+
+  return (
+    <span
+      {...props}
+      className={classes.root}
+      ref={ref as RefObject<HTMLSpanElement>}
+    >
+      {props.children}
+    </span>
+  );
+});

--- a/src/reducers/local-storage.reducer.ts
+++ b/src/reducers/local-storage.reducer.ts
@@ -1,11 +1,14 @@
+import { HelpCard } from '../actions/help-card.actions';
 import { User } from '../actions/user.actions';
+import { Dict } from '../utility/typescript-utils';
 import { getLoggedInState } from '../utility/user-utils';
 
 // We need to be careful about what goes into local storage due to security concerns. So make sure not to add anything
-// that is clearly identifying, such as PII/PHI data, group name, etc.
+// that is clearly identifying of groups, units, or individuals, such as PII/PHI data, group name, etc.
 
 export interface LocalStorageState {
   orgId?: number
+  hideHelpCard?: Dict<boolean>
 }
 
 export const localStorageInitialState: LocalStorageState = {};
@@ -36,6 +39,16 @@ export function localStorageReducer(state = localStorageInitialState, action: an
       return {
         ...state,
         orgId,
+      };
+    }
+    case HelpCard.Actions.Hide.type: {
+      const { helpCardId } = (action as HelpCard.Actions.Hide).payload;
+      return {
+        ...state,
+        hideHelpCard: {
+          ...state.hideHelpCard,
+          [helpCardId]: true,
+        },
       };
     }
     default:

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -56,6 +56,11 @@ theme.overrides = {
       boxShadow: 'none',
     },
   },
+  MuiButton: {
+    root: {
+      textTransform: 'none',
+    },
+  },
   MuiButtonBase: {
     root: {
       '&.MuiButton-text.MuiButton-textSizeLarge': {
@@ -211,12 +216,18 @@ theme.overrides = {
       },
     },
   },
+  MuiTooltip: {
+    tooltip: {
+      fontSize: '12px',
+    },
+  },
 };
 
 theme.props = {
   MuiButton: {
     color: 'primary',
     variant: 'contained',
+    disableElevation: true,
   },
   MuiIconButton: {
     color: 'primary',
@@ -231,6 +242,9 @@ theme.props = {
     InputLabelProps: {
       shrink: true,
     },
+  },
+  MuiTooltip: {
+    arrow: true,
   },
 };
 

--- a/src/utility/tooltip-text.ts
+++ b/src/utility/tooltip-text.ts
@@ -1,0 +1,14 @@
+export const tooltipText = {
+  nonPii: `
+    Can view all data that is non-PII (Personally Identifiable Information) and non-PHI (Personal Health Information) 
+    within the units they have access to.
+  `,
+  pii: `
+    Can view all data that is PII (Personally Identifiable Information) and non-PHI (Personal Health Information) 
+    within the units they have access to.
+  `,
+  phi: `
+    Can view all data that is PII (Personally Identifiable Information) and PHI (Personal Health Information) 
+    within the units they have access to.
+  `,
+};

--- a/src/utility/typescript-utils.ts
+++ b/src/utility/typescript-utils.ts
@@ -1,1 +1,3 @@
 export type OverrideType<T, R> = Omit<T, keyof R> & R;
+
+export type Dict<T> = { [key: string]: T };


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1199567281386165

You should see help text appear on the following pages:
- Data Export
- Muster
- Roles
- Roster Columns
- Roster
- Units
- Users
- Workspaces

Clicking "Ok, I got it" on any of the help cards should hide the card and prevent it from showing anymore for that page (as long as local storage isn't cleared).

Clicking the `(i)` button next to the page header should show the same info as the card (in case the user has already hidden the card but wants to see the help text again).

<img width="1290" alt="Screen Shot 2021-02-01 at 8 17 26 AM" src="https://user-images.githubusercontent.com/3220897/106486047-18c5f380-6466-11eb-9504-ec25528a5a54.png">

<img width="789" alt="Screen Shot 2021-02-01 at 8 18 22 AM" src="https://user-images.githubusercontent.com/3220897/106486063-1bc0e400-6466-11eb-84ab-88f208a67637.png">
