### PR TITLE
Separate Unit from Role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ server/.env
 
 # ide files
 /.idea
+.vscode/launch.json
 
 # logs
 npm-debug.log*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "eslint.workingDirectories": [
+    ".",
+    "server"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3765,9 +3765,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -7449,7 +7449,7 @@
     "eslint": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "integrity": "sha1-YiYtZylzn5J1cjgkMC+yJ8jJP/s=",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -7493,7 +7493,7 @@
         "ansi-escapes": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+          "integrity": "sha1-pcR8xDGB8fOP/XB2g3cA05VSKmE=",
           "requires": {
             "type-fest": "^0.11.0"
           },
@@ -7501,14 +7501,14 @@
             "type-fest": {
               "version": "0.11.0",
               "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-              "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+              "integrity": "sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E="
             }
           }
         },
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
         },
         "ansi-styles": {
           "version": "4.2.1",
@@ -7522,7 +7522,7 @@
         "cli-cursor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
           "requires": {
             "restore-cursor": "^3.1.0"
           }
@@ -7530,12 +7530,12 @@
         "cli-width": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-          "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+          "integrity": "sha1-ovSEN6LKqaIkNueUvwceyeYc7fY="
         },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -7543,7 +7543,7 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
         },
         "debug": {
           "version": "4.1.1",
@@ -7556,7 +7556,7 @@
         "eslint-utils": {
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
           }
@@ -7564,7 +7564,7 @@
         "figures": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+          "integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
@@ -7572,7 +7572,7 @@
         "glob-parent": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -7580,7 +7580,7 @@
         "globals": {
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "integrity": "sha1-oYgTV2pBsAokqX5/gVkYwuGZJfg=",
           "requires": {
             "type-fest": "^0.8.1"
           }
@@ -7588,12 +7588,12 @@
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
         },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+          "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw="
         },
         "import-fresh": {
           "version": "3.2.1",
@@ -7607,7 +7607,7 @@
         "inquirer": {
           "version": "7.3.3",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-          "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+          "integrity": "sha1-BNF2sq8Er8FXqD/XwQDpjuCq0AM=",
           "requires": {
             "ansi-escapes": "^4.2.1",
             "chalk": "^4.1.0",
@@ -7627,7 +7627,7 @@
             "chalk": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-              "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+              "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -7636,7 +7636,7 @@
             "strip-ansi": {
               "version": "6.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
               "requires": {
                 "ansi-regex": "^5.0.0"
               }
@@ -7646,27 +7646,27 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
         },
         "mimic-fn": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+          "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "mute-stream": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+          "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0="
         },
         "onetime": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
           "requires": {
             "mimic-fn": "^2.1.0"
           }
@@ -7674,17 +7674,17 @@
         "regexpp": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+          "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8="
         },
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+          "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY="
         },
         "restore-cursor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
           "requires": {
             "onetime": "^5.1.0",
             "signal-exit": "^3.0.2"
@@ -7693,12 +7693,12 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -7708,7 +7708,7 @@
             "strip-ansi": {
               "version": "6.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
               "requires": {
                 "ansi-regex": "^5.0.0"
               }
@@ -7718,7 +7718,7 @@
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "requires": {
             "ansi-regex": "^4.1.0"
           },
@@ -7726,14 +7726,14 @@
             "ansi-regex": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+              "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
             }
           }
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -8107,7 +8107,7 @@
     "espree": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "integrity": "sha1-d/xy4f10SiBSwg84pbV1gy6Cc0o=",
       "requires": {
         "acorn": "^7.1.1",
         "acorn-jsx": "^5.2.0",
@@ -8490,7 +8490,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -10435,9 +10435,9 @@
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
       "version": "6.2.1",
@@ -12048,7 +12048,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -13062,9 +13062,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha1-1iQFDtu0SHStyhK7mlLsY8t4JXk="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -17690,11 +17690,11 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha1-2lgZ/QSdVXTyjoipvMbbxubzkGs=",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/multer": "^1.4.4",
     "@types/uuid": "^8.3.0",
     "aws-sdk": "^2.810.0",
-    "axios": "^0.20.0",
+    "axios": "^0.21.1",
     "axios-cookiejar-support": "^1.0.0",
     "axios-retry": "^3.1.9",
     "body-parser": "^1.19.0",

--- a/server/api/access-request/access-request.controller.ts
+++ b/server/api/access-request/access-request.controller.ts
@@ -1,5 +1,5 @@
 import { Response } from 'express';
-import { getConnection } from 'typeorm';
+import { getManager } from 'typeorm';
 import { BadRequestError, NotFoundError, UnauthorizedError } from '../../util/error-types';
 import { ApiRequest, OrgParam } from '../index';
 import { Org } from '../org/org.model';
@@ -54,22 +54,20 @@ class AccessRequestController {
     });
 
     let newRequest: AccessRequest | null = null;
-    await getConnection().transaction(async manager => {
-      if (request) {
-        if (request.status === AccessRequestStatus.Denied) {
-          // Remove the denied request so that we can issue a new one.
-          await manager.remove(request);
-        } else {
-          throw new BadRequestError('The access request has already been issued.');
-        }
+    if (request) {
+      if (request.status === AccessRequestStatus.Denied) {
+        // Remove the denied request so that we can issue a new one.
+        await request.remove();
+      } else {
+        throw new BadRequestError('The access request has already been issued.');
       }
+    }
 
-      request = new AccessRequest();
-      request.user = req.appUser;
-      request.org = org;
-      request.requestDate = new Date();
-      newRequest = await manager.save(request);
-    });
+    request = new AccessRequest();
+    request.user = req.appUser;
+    request.org = org;
+    request.requestDate = new Date();
+    newRequest = await request.save();
 
     res.status(201);
     res.json(newRequest);
@@ -149,21 +147,14 @@ class AccessRequestController {
       throw new NotFoundError('Role was not found');
     }
 
-    if (!req.appRole || !req.appRole.isSupersetOf(role)) {
+    if (!req.appUserRole || !req.appUserRole.role.isSupersetOf(role)) {
       throw new UnauthorizedError('Unable to assign a role with greater permissions than your current role.');
     }
 
     const user = await User.findOne({
-      relations: ['roles'],
+      relations: ['userRoles', 'userRoles.role', 'userRoles.role.org'],
       where: {
         edipi: accessRequest.user!.edipi,
-      },
-      join: {
-        alias: 'user',
-        leftJoinAndSelect: {
-          roles: 'user.roles',
-          org: 'roles.org',
-        },
       },
     });
 
@@ -171,18 +162,20 @@ class AccessRequestController {
       throw new NotFoundError('User was not found');
     }
 
-    const existingRole = user.roles!.find(userRole => userRole.org!.id === orgId);
-
-    if (existingRole) {
+    const userRole = user.userRoles.find(ur => ur.role.org!.id === orgId);
+    if (userRole?.role) {
       await accessRequest.remove();
       throw new BadRequestError('User already has a role in the organization');
     }
 
-    user.roles!.push(role);
+    let processedRequest: AccessRequest | null = null;
 
-    await user.save();
+    await getManager().transaction(async manager => {
+      await user.addRole(manager, role);
+      await manager.save(user);
 
-    const processedRequest = await accessRequest.remove();
+      processedRequest = await manager.remove(accessRequest);
+    });
 
     res.json({
       success: true,

--- a/server/api/export/export.controller.ts
+++ b/server/api/export/export.controller.ts
@@ -33,7 +33,7 @@ class ExportController {
     //
     // Get ES data and stream to client.
     //
-    const index = req.appRole!.getKibanaIndex();
+    const index = req.appUserRole!.getKibanaIndex();
     const scrollQueue = [] as SearchResponse<any>[];
     try {
       scrollQueue.push(await elasticsearch.search({
@@ -102,7 +102,7 @@ class ExportController {
 
     const orgId = req.appOrg!.id;
 
-    const queryBuilder = await Roster.queryAllowedRoster(req.appOrg!, req.appRole!);
+    const queryBuilder = await Roster.queryAllowedRoster(req.appOrg!, req.appUserRole!);
     const rosterData = await queryBuilder
       .orderBy({
         edipi: 'ASC',
@@ -136,7 +136,7 @@ class ExportController {
 
     const individuals = await getRosterMusterStats({
       org: req.appOrg!,
-      role: req.appRole!,
+      userRole: req.appUserRole!,
       interval,
       intervalCount,
       unitId: req.query.unitId,

--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -13,7 +13,7 @@ import musterRoutes from './muster';
 import exportRoutes from './export';
 import { User } from './user/user.model';
 import { Org } from './org/org.model';
-import { Role } from './role/role.model';
+import { UserRole } from './user/user-role.model';
 import { Workspace } from './workspace/workspace.model';
 
 const router = express.Router();
@@ -33,7 +33,7 @@ router.use('/reingest', reingestRoutes);
 export interface ApiRequest<ReqParams = object, ReqBody = object, ReqQuery = object, ResBody = object> extends Request<ReqParams, ResBody, ReqBody, ReqQuery> {
   appUser: User,
   appOrg?: Org,
-  appRole?: Role,
+  appUserRole?: UserRole,
   appWorkspace?: Workspace,
   kibanaApi?: KibanaApi,
 }

--- a/server/api/muster/muster.controller.ts
+++ b/server/api/muster/muster.controller.ts
@@ -46,7 +46,7 @@ class MusterController {
 
     const individuals = await getRosterMusterStats({
       org: req.appOrg!,
-      role: req.appRole!,
+      userRole: req.appUserRole!,
       interval,
       intervalCount,
       unitId: req.query.unitId || undefined,
@@ -70,7 +70,7 @@ class MusterController {
     const monthsCount = parseInt(req.query.monthsCount ?? '6');
 
     const unitTrends = await getUnitMusterStats({
-      role: req.appRole!,
+      userRole: req.appUserRole!,
       weeksCount,
       monthsCount,
     });

--- a/server/api/notification/notification.controller.ts
+++ b/server/api/notification/notification.controller.ts
@@ -25,10 +25,11 @@ class NotificationController {
       },
     });
 
-    const all = req.appRole!.allowedNotificationEvents.length === 1
-      && req.appRole?.allowedNotificationEvents[0] === '*';
+    const role = req.appUserRole!.role;
+    const all = role.allowedNotificationEvents.length === 1
+      && role.allowedNotificationEvents[0] === '*';
     const available = all ? notifications : notifications.filter(notification => {
-      return req.appRole!.allowedNotificationEvents.indexOf(notification.id) >= 0;
+      return role.allowedNotificationEvents.indexOf(notification.id) >= 0;
     });
 
     res.json(available.map(sanitizeNotification));

--- a/server/api/roster/roster.controller.ts
+++ b/server/api/roster/roster.controller.ts
@@ -21,7 +21,7 @@ import { Org } from '../org/org.model';
 import { CustomColumnConfig, CustomRosterColumn } from './custom-roster-column.model';
 import { Unit } from '../unit/unit.model';
 import { CustomColumnValue, RosterColumnInfo, RosterColumnType } from './roster.types';
-import { Role } from '../role/role.model';
+import { UserRole } from '../user/user-role.model';
 import { ChangeType, RosterHistory } from './roster-history.model';
 import { baseRosterColumns } from './roster-entity';
 
@@ -101,7 +101,7 @@ class RosterController {
   }
 
   async getRosterTemplate(req: ApiRequest, res: Response) {
-    const columns = await Roster.getAllowedColumns(req.appOrg!, req.appRole!);
+    const columns = await Roster.getAllowedColumns(req.appOrg!, req.appUserRole!.role);
     const headers: string[] = ['unit'];
     const example: string[] = ['unit1'];
     columns.forEach(column => {
@@ -138,11 +138,11 @@ class RosterController {
   }
 
   async getRoster(req: ApiRequest<OrgParam, any, GetRosterQuery>, res: Response) {
-    res.json(await internalSearchRoster(req.query, req.appOrg!, req.appRole!));
+    res.json(await internalSearchRoster(req.query, req.appOrg!, req.appUserRole!));
   }
 
   async searchRoster(req: ApiRequest<OrgParam, SearchRosterBody, GetRosterQuery>, res: Response) {
-    res.json(await internalSearchRoster(req.query, req.appOrg!, req.appRole!, req.body));
+    res.json(await internalSearchRoster(req.query, req.appOrg!, req.appUserRole!, req.body));
   }
 
   async uploadRosterEntries(req: ApiRequest<OrgParam>, res: Response) {
@@ -169,7 +169,7 @@ class RosterController {
       },
     });
 
-    const columns = await Roster.getAllowedColumns(org, req.appRole!);
+    const columns = await Roster.getAllowedColumns(org, req.appUserRole!.role);
     const errors: RosterUploadErrorInfo[] = [];
     const existingEntries = await Roster.find({
       where: {
@@ -251,7 +251,7 @@ class RosterController {
   }
 
   async getRosterInfo(req: ApiRequest<OrgParam>, res: Response) {
-    const columns = await Roster.getAllowedColumns(req.appOrg!, req.appRole!);
+    const columns = await Roster.getAllowedColumns(req.appOrg!, req.appUserRole!.role);
     res.json(columns);
   }
 
@@ -328,7 +328,7 @@ class RosterController {
 
     const entry = new Roster();
     entry.unit = unit;
-    const columns = await Roster.getAllowedColumns(req.appOrg!, req.appRole!);
+    const columns = await Roster.getAllowedColumns(req.appOrg!, req.appUserRole!.role);
     await setRosterParamsFromBody(req.appOrg!, entry, req.body, columns, true);
     const newRosterEntry = await entry.save();
 
@@ -338,7 +338,7 @@ class RosterController {
   async getRosterEntry(req: ApiRequest<OrgRosterParams>, res: Response) {
     const rosterId = req.params.rosterId;
 
-    const queryBuilder = await Roster.queryAllowedRoster(req.appOrg!, req.appRole!);
+    const queryBuilder = await Roster.queryAllowedRoster(req.appOrg!, req.appUserRole!);
     const rosterEntry = await queryBuilder
       .andWhere('roster.id=\':id\'', {
         id: rosterId,
@@ -404,7 +404,7 @@ class RosterController {
         entry.unit = unit;
       }
 
-      const columns = await Roster.getAllowedColumns(req.appOrg!, req.appRole!);
+      const columns = await Roster.getAllowedColumns(req.appOrg!, req.appUserRole!.role);
       await setRosterParamsFromBody(req.appOrg!, entry, req.body, columns);
       const updatedRosterEntry = await manager.save(entry);
       res.json(updatedRosterEntry);
@@ -413,12 +413,12 @@ class RosterController {
 
 }
 
-async function internalSearchRoster(query: GetRosterQuery, org: Org, role: Role, searchParams?: SearchRosterBody) {
+async function internalSearchRoster(query: GetRosterQuery, org: Org, userRole: UserRole, searchParams?: SearchRosterBody) {
   const limit = parseInt(query.limit ?? '100');
   const page = parseInt(query.page ?? '0');
   const orderBy = query.orderBy || 'edipi';
   const sortDirection = query.sortDirection || 'ASC';
-  const rosterColumns = await Roster.getAllowedColumns(org, role);
+  const rosterColumns = await Roster.getAllowedColumns(org, userRole.role);
 
   const columns: RosterColumnInfo[] = [{
     name: 'unit',
@@ -433,7 +433,7 @@ async function internalSearchRoster(query: GetRosterQuery, org: Org, role: Role,
 
   async function makeQueryBuilder() {
     if (!searchParams) {
-      return Roster.queryAllowedRoster(org, role);
+      return Roster.queryAllowedRoster(org, userRole);
     }
     return Object.keys(searchParams)
       .reduce((queryBuilder, key) => {
@@ -485,7 +485,7 @@ async function internalSearchRoster(query: GetRosterQuery, org: Org, role: Role,
         }
 
         throw new BadRequestError('Malformed search query. Received unexpected value for "op".');
-      }, await Roster.queryAllowedRoster(org, role));
+      }, await Roster.queryAllowedRoster(org, userRole));
   }
 
   const queryBuilder = await makeQueryBuilder();

--- a/server/api/roster/roster.model.ts
+++ b/server/api/roster/roster.model.ts
@@ -11,6 +11,7 @@ import { Org } from '../org/org.model';
 import { Role } from '../role/role.model';
 import { CustomRosterColumn } from './custom-roster-column.model';
 import { baseRosterColumns, RosterEntity } from './roster-entity';
+import { UserRole } from '../user/user-role.model';
 
 @Entity()
 @Unique(['edipi', 'unit'])
@@ -31,12 +32,12 @@ export class Roster extends RosterEntity {
     return `roster.${snakeCase(column.name)}`;
   }
 
-  static async queryAllowedRoster(org: Org, role: Role, columns?: RosterColumnInfo[]) {
+  static async queryAllowedRoster(org: Org, userRole: UserRole, columns?: RosterColumnInfo[]) {
     //
     // Query the roster, returning only columns and rows that are allowed for the role of the requester.
     //
     if (!columns) {
-      columns = await Roster.getAllowedColumns(org, role);
+      columns = await Roster.getAllowedColumns(org, userRole.role);
     }
     const queryBuilder = Roster.createQueryBuilder('roster').select([]);
     queryBuilder.leftJoin('roster.unit', 'u');
@@ -52,7 +53,7 @@ export class Roster extends RosterEntity {
     // Filter out roster entries that are not on the active roster or are not allowed by the role's index prefix.
     return queryBuilder
       .where('u.org_id = :orgId', { orgId: org.id })
-      .andWhere('u.id like :name', { name: role.indexPrefix.replace('*', '%') });
+      .andWhere('u.id like :name', { name: userRole.indexPrefix.replace('*', '%') });
   }
 
   static async getAllowedColumns(org: Org, role: Role) {

--- a/server/api/unit/unit.controller.ts
+++ b/server/api/unit/unit.controller.ts
@@ -14,7 +14,7 @@ import { ChangeType, RosterHistory } from '../roster/roster-history.model';
 class UnitController {
 
   async getUnits(req: ApiRequest<OrgParam>, res: Response) {
-    if (!req.appRole?.indexPrefix) {
+    if (!req.appUserRole?.indexPrefix) {
       res.json([]);
       return;
     }
@@ -23,7 +23,7 @@ class UnitController {
       .leftJoinAndSelect('unit.org', 'org')
       .where('unit.org_id=:orgId', { orgId: req.appOrg!.id })
       .andWhere('unit.id like :unitFilter', {
-        unitFilter: req.appRole!.indexPrefix.replace('*', '%'),
+        unitFilter: req.appUserRole!.indexPrefix.replace('*', '%'),
       })
       .orderBy('unit.id', 'ASC')
       .getMany();
@@ -35,7 +35,7 @@ class UnitController {
     if (!req.body.id) {
       throw new BadRequestError('An ID must be supplied when adding a unit.');
     }
-    if (!matchWildcardString(req.body.id, req.appRole!.indexPrefix)) {
+    if (!matchWildcardString(req.body.id, req.appUserRole!.indexPrefix)) {
       throw new BadRequestError('The provided unit ID does not conform to the unit filter for your role.');
     }
     if (!req.body.name) {
@@ -66,7 +66,7 @@ class UnitController {
   }
 
   async updateUnit(req: ApiRequest<OrgUnitParams, UnitData>, res: Response) {
-    if (!matchWildcardString(req.params.unitId, req.appRole!.indexPrefix)) {
+    if (!matchWildcardString(req.params.unitId, req.appUserRole!.indexPrefix)) {
       // If they don't have permission to see the unit, treat it as not found
       throw new NotFoundError('The unit could not be found.');
     }
@@ -114,7 +114,7 @@ class UnitController {
   }
 
   async deleteUnit(req: ApiRequest<OrgUnitParams>, res: Response) {
-    if (!matchWildcardString(req.params.unitId, req.appRole!.indexPrefix)) {
+    if (!matchWildcardString(req.params.unitId, req.appUserRole!.indexPrefix)) {
       // If they don't have permission to see the unit, treat it as not found
       throw new NotFoundError('The unit could not be found.');
     }

--- a/server/api/user/user-role.model.ts
+++ b/server/api/user/user-role.model.ts
@@ -1,0 +1,57 @@
+import {
+  Entity,
+  Column,
+  BaseEntity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Role } from '../role/role.model';
+import { User } from './user.model';
+import { escapeRegExp } from '../../util/util';
+
+@Entity()
+export class UserRole extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => User, user => user.userRoles)
+  user!: User;
+
+  @ManyToOne(() => Role, role => role.userRoles, {
+    onDelete: 'RESTRICT',
+  })
+  role!: Role;
+
+  @Column({
+    default: '',
+  })
+  indexPrefix!: string;
+
+  getUnitFilter() {
+    return this.indexPrefix.replace(new RegExp(escapeRegExp('-'), 'g'), '_');
+  }
+
+  getKibanaIndex() {
+    if (this.user.rootAdmin) {
+      return '*';
+    }
+    const suffix = this.role.canViewPHI ? 'phi' : (this.role.canViewPII ? 'pii' : 'base');
+    return `${this.role.org!.indexPrefix}-${this.getUnitFilter()}-${suffix}-*`;
+  }
+
+  getKibanaIndexForMuster(unitId?: string) {
+    return `${this.role.org!.indexPrefix}-${unitId || this.getUnitFilter()}-phi-*`;
+  }
+
+  getKibanaUserClaim() {
+    return `org${this.role.org!.id}-role${this.role.id}`;
+  }
+
+  getKibanaRoles() {
+    if (this.role.canManageWorkspace) {
+      return 'kibana_admin';
+    }
+    return 'kibana_ro_strict';
+  }
+}

--- a/server/api/user/user.controller.ts
+++ b/server/api/user/user.controller.ts
@@ -1,4 +1,5 @@
 import { Response } from 'express';
+import { getManager } from 'typeorm';
 import { AccessRequest } from '../access-request/access-request.model';
 import { ApiRequest, OrgEdipiParams, OrgParam } from '../index';
 import { User } from './user.model';
@@ -52,7 +53,7 @@ class UserController {
 
     const updatedUser = await user.save();
 
-    await res.status(201).json(updatedUser);
+    res.status(201).json(updatedUser);
   }
 
   async upsertUser(req: ApiRequest<OrgParam, UpsertUserBody>, res: Response) {
@@ -81,86 +82,60 @@ class UserController {
       throw new NotFoundError('The role was not found in the organization.');
     }
 
-    if (edipi === req.appUser.edipi && req.appRole?.id !== roleId) {
+    if (edipi === req.appUser.edipi && req.appUserRole?.role.id !== roleId) {
       throw new BadRequestError('You may not edit your own role.');
     }
 
-    let newUser = false;
     let user = await User.findOne({
-      relations: ['roles'],
+      relations: ['userRoles', 'userRoles.role', 'userRoles.role.org'],
       where: {
         edipi,
       },
-      join: {
-        alias: 'user',
-        leftJoinAndSelect: {
-          roles: 'user.roles',
-          org: 'roles.org',
-        },
-      },
     });
 
-    if (!user) {
-      user = new User();
-      user.edipi = edipi;
-      newUser = true;
-    }
+    let newUser = false;
+    let savedUser: User | null = null;
 
-    if (!user.roles) {
-      user.roles = [];
-    }
+    await getManager().transaction(async manager => {
+      if (!user) {
+        user = manager.create<User>('User', {
+          edipi,
+        });
+        newUser = true;
+      }
 
-    const orgRoleIndex = user.roles.findIndex(userRole => userRole.org!.id === org.id);
+      if (firstName) {
+        user.firstName = firstName;
+      }
+      if (lastName) {
+        user.lastName = lastName;
+      }
 
-    if (orgRoleIndex >= 0) {
-      user.roles.splice(orgRoleIndex, 1);
-    }
+      if (newUser) {
+        await user.addRole(manager, role);
+      } else {
+        await user.changeRole(manager, role);
+      }
+      savedUser = await manager.save(user);
+    });
 
-    user.roles.push(role);
-
-    if (firstName) {
-      user.firstName = firstName;
-    }
-
-    if (lastName) {
-      user.lastName = lastName;
-    }
-
-    const updatedUser = await user.save();
-
-    await res.status(newUser ? 201 : 200).json(updatedUser);
+    res.status(newUser ? 201 : 200).json(savedUser ?? {});
   }
 
   async getOrgUsers(req: ApiRequest<OrgParam>, res: Response) {
-    // TODO: This could potentially be optimized with something like this:
-    // SELECT "user".*
-    //   FROM role
-    // INNER JOIN user_roles
-    //   ON role.id = user_roles.role
-    // INNER JOIN "user"
-    //   ON user_roles."user" = "user"."EDIPI"
-    // WHERE role.org_id=1
-
+    const orgUsers: User[] = [];
     const roles = await Role.find({
+      relations: ['userRoles', 'userRoles.user', 'userRoles.user.userRoles', 'userRoles.user.userRoles.role'],
       where: {
-        org: req.appOrg!.id,
+        org: req.appOrg,
       },
     });
-
-    const users: User[] = [];
     for (const role of roles) {
-      const roleUsers = await User.createQueryBuilder('user')
-        .innerJoin('user.roles', 'role')
-        .where('role.id = :id', { id: role.id })
-        .getMany();
-
-      roleUsers.forEach(user => {
-        user.roles = [role];
-        users.push(user);
-      });
+      for (const userRole of (role.userRoles ?? [])) {
+        orgUsers.push(userRole.user);
+      }
     }
-
-    res.json(users);
+    res.json(orgUsers);
   }
 
   async removeUserFromGroup(req: ApiRequest<OrgEdipiParams>, res: Response) {
@@ -171,20 +146,22 @@ class UserController {
     }
 
     const user = await User.findOne({
-      relations: ['roles', 'roles.org'],
+      relations: ['userRoles', 'userRoles.role', 'userRoles.role.org'],
       where: {
         edipi: userEDIPI,
       },
     });
 
-    const roleIndex = (user?.roles ?? []).findIndex(userRole => userRole.org!.id === req.appOrg!.id);
+    let savedUser: User | null = null;
+    const userRole = user?.userRoles.find(ur => ur.role.org!.id === req.appOrg!.id);
 
-    if (roleIndex !== -1) {
-      user!.roles!.splice(roleIndex, 1);
-      res.json(await user!.save());
-    } else {
-      res.json({});
+    if (user && userRole) {
+      await getManager().transaction(async manager => {
+        await user.removeRole(manager, userRole.role);
+        savedUser = await manager.save(user);
+      });
     }
+    res.json(savedUser ?? {});
   }
 
   async getAccessRequests(req: ApiRequest, res: Response) {

--- a/server/api/user/user.model.ts
+++ b/server/api/user/user.model.ts
@@ -1,7 +1,9 @@
 import {
-  Entity, PrimaryColumn, Column, BaseEntity, ManyToMany, JoinTable,
+  Entity, PrimaryColumn, Column, BaseEntity, OneToMany, EntityManager,
 } from 'typeorm';
+import { NotFoundError } from '../../util/error-types';
 import { Role } from '../role/role.model';
+import { UserRole } from './user-role.model';
 
 const internalUserEdipi = 'internal';
 
@@ -12,23 +14,6 @@ export class User extends BaseEntity {
     length: 10,
   })
   edipi!: string;
-
-  @ManyToMany(() => Role, {
-    cascade: true,
-    onDelete: 'RESTRICT',
-  })
-  @JoinTable({
-    name: 'user_roles',
-    joinColumn: {
-      name: 'user',
-      referencedColumnName: 'edipi',
-    },
-    inverseJoinColumn: {
-      name: 'role',
-      referencedColumnName: 'id',
-    },
-  })
-  roles?: Role[];
 
   @Column()
   firstName!: string;
@@ -59,6 +44,80 @@ export class User extends BaseEntity {
     default: false,
   })
   isRegistered?: boolean;
+
+
+  @OneToMany(() => UserRole, userRole => userRole.user)
+  userRoles!: UserRole[];
+
+  async addRole(manager: EntityManager, role: Role, indexPrefix?: string): Promise<User> {
+    let userRole = await this.findUserRole(role);
+    if (!userRole) {
+      userRole = manager.create<UserRole>('UserRole', {
+        user: this,
+        role,
+        indexPrefix: indexPrefix || role.defaultIndexPrefix,
+      });
+      this.userRoles.push(userRole);
+      await manager.save(userRole);
+    }
+    return this;
+  }
+
+  async addRoles(manager: EntityManager, roles: Role[]): Promise<User> {
+    for (const role of roles) {
+      await this.addRole(manager, role);
+    }
+    return this;
+  }
+
+  async removeRole(manager: EntityManager, role?: Role, userRole?: UserRole): Promise<User> {
+    if (role || userRole) {
+      const found = userRole ?? await this.findUserRole(role!);
+      if (found) {
+        const index = this.userRoles.indexOf(found);
+        this.userRoles.splice(index, 1);
+        await manager.remove(found);
+      } else if (role) {
+        throw new NotFoundError(`Error removing role. User ${this.edipi} does not have role ${role.name}`);
+      }
+    }
+    return this;
+  }
+
+  async changeRole(manager: EntityManager, role: Role, indexPrefix?: string): Promise<User> {
+    let userRole = await this.findUserRole(role);
+    if (!userRole) {
+      if (this.userRoles.length === 1) {
+        await this.removeRole(manager, undefined, this.userRoles[0]);
+      }
+      userRole = manager.create<UserRole>('UserRole', {
+        user: this,
+        role,
+        indexPrefix: indexPrefix || role.defaultIndexPrefix,
+      });
+      this.userRoles.push(userRole);
+      await manager.save(userRole);
+    }
+    return this;
+  }
+
+  protected async findUserRole(role: Role): Promise<UserRole | undefined> {
+    if (!this.userRoles) {
+      if (!this.hasId()) {
+        this.userRoles = [];
+      } else {
+        this.userRoles = await UserRole.find({
+          relations: ['role', 'role.org'],
+          where: {
+            user: this,
+          },
+        });
+      }
+    }
+    return this.userRoles.find(userRole => {
+      return userRole.role.id === role.id;
+    });
+  }
 
   public isInternal() {
     return this.edipi === internalUserEdipi;

--- a/server/api/workspace/workspace.controller.ts
+++ b/server/api/workspace/workspace.controller.ts
@@ -13,7 +13,7 @@ import { Role } from '../role/role.model';
 class WorkspaceController {
 
   async getOrgWorkspaces(req: ApiRequest, res: Response) {
-    if (!req.appOrg || !req.appRole) {
+    if (!req.appOrg || !req.appUserRole) {
       throw new NotFoundError('Organization was not found.');
     }
 
@@ -31,7 +31,7 @@ class WorkspaceController {
   }
 
   async getOrgWorkspaceTemplates(req: ApiRequest, res: Response) {
-    if (!req.appOrg || !req.appRole) {
+    if (!req.appOrg || !req.appUserRole) {
       throw new NotFoundError('Organization was not found.');
     }
 
@@ -50,8 +50,8 @@ class WorkspaceController {
       throw new NotFoundError('Organization was not found.');
     }
 
-    if (!req.appRole) {
-      throw new NotFoundError('req.appRole is not set');
+    if (!req.appUserRole) {
+      throw new NotFoundError('req.appUserRole is not set');
     }
 
     if (!req.body.name) {
@@ -92,7 +92,7 @@ class WorkspaceController {
       // NOTE: We can't connect to the Kibana API with middleware when creating a workspace, since the workspace
       // doesn't exist yet to build the JWT with. So connect manually now that it exists.
       await KibanaApi.connect(req);
-      await setupKibanaWorkspace(newWorkspace, req.appRole!, req.kibanaApi!);
+      await setupKibanaWorkspace(newWorkspace, req.appUserRole!.role, req.kibanaApi!);
     });
 
     await res.status(201).json(newWorkspace);

--- a/server/kibana/dashboard/read-only-rest.controller.ts
+++ b/server/kibana/dashboard/read-only-rest.controller.ts
@@ -1,7 +1,7 @@
 import { Response, NextFunction } from 'express';
 import { ApiRequest } from '../../api';
 import { User } from '../../api/user/user.model';
-import { Role } from '../../api/role/role.model';
+import { UserRole } from '../../api/user/user-role.model';
 import { Workspace } from '../../api/workspace/workspace.model';
 import config from '../../config';
 
@@ -14,7 +14,7 @@ class ReadOnlyRestController {
   login(req: ApiRequest<null, null, LoginQuery>, res: Response) {
     console.log('ror login()');
 
-    const rorJwt = buildJWT(req.appUser, req.appRole!, req.appWorkspace!);
+    const rorJwt = buildJWT(req.appUser, req.appUserRole!, req.appWorkspace!);
     console.log('ror jwt', rorJwt);
 
     res.cookie('orgId', req.appOrg!.id, { httpOnly: true });
@@ -39,13 +39,13 @@ class ReadOnlyRestController {
 }
 
 // Builds ReadOnlyRest JWT token.
-export function buildJWT(user: User, role: Role, workspace: Workspace) {
+export function buildJWT(user: User, userRole: UserRole, workspace: Workspace) {
   console.log('ror buildJWT()');
 
   const claims = {
     sub: user.edipi,
     iss: 'https://statusengine.mysymptoms.mil',
-    roles: role.getKibanaRoles(),
+    roles: userRole.getKibanaRoles(),
     firecares_id: `${workspace!.id}`, // TODO: Rename 'firecares_id'.
   };
 

--- a/server/kibana/kibana-api.ts
+++ b/server/kibana/kibana-api.ts
@@ -12,8 +12,8 @@ export class KibanaApi {
   private axiosInstance?: AxiosInstance;
 
   static async connect(req: ApiRequest, res?: Response, next?: NextFunction) {
-    if (!req.appRole) {
-      throw new Error('KibanaApi.connect() requires req.appRole to be set');
+    if (!req.appUserRole) {
+      throw new Error('KibanaApi.connect() requires req.appUserRole to be set');
     }
     if (!req.appOrg) {
       throw new Error('KibanaApi.connect() requires req.appOrg to be set');
@@ -29,7 +29,7 @@ export class KibanaApi {
       baseURL: `${config.kibana.uri}`,
       headers: {
         'kbn-xsrf': 'true', // Kibana requires 'kbn-xsrf' to be set or it will return an error. It can be any string.
-        'x-se-fire-department-all': req.appRole.getKibanaIndex(),
+        'x-se-fire-department-all': req.appUserRole.getKibanaIndex(),
       },
       maxRedirects: 0,
       httpsAgent: new https.Agent({
@@ -43,7 +43,7 @@ export class KibanaApi {
     kibanaApi.axiosInstance.defaults.jar = new tough.CookieJar();
 
     // Start a Kibana Session on behalf of the requesting user, storing rorCookie in cookie jar.
-    const rorJwt = buildJWT(req.appUser, req.appRole, req.appWorkspace);
+    const rorJwt = buildJWT(req.appUser, req.appUserRole, req.appWorkspace);
 
     try {
       await kibanaApi.axiosInstance.get(`login?jwt=${rorJwt}`);

--- a/server/kibana/kibana-proxy-settings.ts
+++ b/server/kibana/kibana-proxy-settings.ts
@@ -16,8 +16,8 @@ const kibanaProxyConfig: Config = {
 
   // add custom headers to request
   onProxyReq: (proxyReq: ClientRequest, req: ProxyRequest) => {
-    if (req.appRole) {
-      proxyReq.setHeader('x-se-fire-department-all', req.appRole.getKibanaIndex());
+    if (req.appUserRole) {
+      proxyReq.setHeader('x-se-fire-department-all', req.appUserRole.getKibanaIndex());
     }
   },
 

--- a/server/migration/1610729959726-SeparateUnitFromRole.ts
+++ b/server/migration/1610729959726-SeparateUnitFromRole.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SeparateUnitFromRole1610729959726 implements MigrationInterface {
+  name = 'SeparateUnitFromRole1610729959726';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "role" RENAME COLUMN "index_prefix" TO "default_index_prefix"`);
+    await queryRunner.query(`CREATE TABLE "user_role" ("id" SERIAL NOT NULL, "user_edipi" character varying(10) NOT NULL, "role_id" integer NOT NULL, "index_prefix" character varying NOT NULL DEFAULT '', CONSTRAINT "PK_fb2e442d14add3cefbdf33c4561" PRIMARY KEY ("id"))`);
+    await queryRunner.query(`ALTER TABLE "user_role" ADD CONSTRAINT "FK_da99ac77b2109579404ede76460" FOREIGN KEY ("user_edipi") REFERENCES "user"("edipi") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    await queryRunner.query(`ALTER TABLE "user_role" ADD CONSTRAINT "FK_32a6fc2fcb019d8e3a8ace0f55f" FOREIGN KEY ("role_id") REFERENCES "role"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`);
+
+    await queryRunner.query(`
+            INSERT INTO user_role (user_edipi, role_id, index_prefix)
+            SELECT ur.user as user_edipi, ur.role as role_id, r.default_index_prefix
+            FROM user_roles ur
+            INNER JOIN role r on r.id = ur.role`);
+
+    await queryRunner.query(`ALTER TABLE "user_roles" DROP CONSTRAINT "FK_0475850442d60bd704c58041551"`);
+    await queryRunner.query(`ALTER TABLE "user_roles" DROP CONSTRAINT "FK_781a1c15149789c1609fe1b0258"`);
+    await queryRunner.query(`DROP TABLE "user_roles"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TABLE "user_roles" ("user" character varying(10) NOT NULL, "role" integer NOT NULL, CONSTRAINT "PK_949caf046fc278bd72bd4cbef84" PRIMARY KEY ("user", "role"))`);
+    await queryRunner.query(`ALTER TABLE "user_roles" ADD CONSTRAINT "FK_781a1c15149789c1609fe1b0258" FOREIGN KEY ("user") REFERENCES "user"("edipi") ON DELETE RESTRICT ON UPDATE NO ACTION`);
+    await queryRunner.query(`ALTER TABLE "user_roles" ADD CONSTRAINT "FK_0475850442d60bd704c58041551" FOREIGN KEY ("role") REFERENCES "role"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`);
+
+    await queryRunner.query(`
+            INSERT INTO user_roles
+            SELECT ur.user_edipi as user, ur.role_id as role
+            FROM user_role ur`);
+
+    await queryRunner.query(`ALTER TABLE "user_role" DROP CONSTRAINT "FK_32a6fc2fcb019d8e3a8ace0f55f"`);
+    await queryRunner.query(`ALTER TABLE "user_role" DROP CONSTRAINT "FK_da99ac77b2109579404ede76460"`);
+    await queryRunner.query(`DROP TABLE "user_role"`);
+    await queryRunner.query(`ALTER TABLE "role" RENAME COLUMN "default_index_prefix" TO "index_prefix"`);
+  }
+
+}

--- a/server/ormconfig.ts
+++ b/server/ormconfig.ts
@@ -12,6 +12,7 @@ import { WorkspaceTemplate } from './api/workspace/workspace-template.model';
 import { CustomRosterColumn } from './api/roster/custom-roster-column.model';
 import { Notification } from './api/notification/notification.model';
 import { UserNotificationSetting } from './api/notification/user-notification-setting.model';
+import { UserRole } from './api/user/user-role.model';
 
 export const ormConfig: PostgresConnectionOptions = {
   type: 'postgres',
@@ -21,6 +22,7 @@ export const ormConfig: PostgresConnectionOptions = {
   password: process.env.SQL_PASSWORD || 'postgres',
   database: process.env.SQL_DATABASE || 'dds',
   entities: [
+    UserRole,
     User,
     Role,
     Org,

--- a/server/sqldb/seed-dev.ts
+++ b/server/sqldb/seed-dev.ts
@@ -1,4 +1,5 @@
 import process from 'process';
+import { getManager, EntityManager } from 'typeorm';
 import database from '.';
 import { Org } from '../api/org/org.model';
 import { Role } from '../api/role/role.model';
@@ -9,6 +10,8 @@ import { Roster } from '../api/roster/roster.model';
 import { CustomRosterColumn } from '../api/roster/custom-roster-column.model';
 import { Unit } from '../api/unit/unit.model';
 
+require('dotenv').config();
+
 export default (async function() {
   if (process.env.NODE_ENV !== 'development') {
     throw new Error('You can only seed the database in a development environment.');
@@ -18,89 +21,97 @@ export default (async function() {
 
   const connection = await database;
 
-  // Create users
-  const groupAdmin = new User();
-  groupAdmin.edipi = '0000000001';
-  groupAdmin.firstName = 'Group';
-  groupAdmin.lastName = 'Admin';
-  groupAdmin.phone = '123-456-7890';
-  groupAdmin.email = 'groupadmin@statusengine.com';
-  groupAdmin.service = 'Space Force';
-  groupAdmin.isRegistered = true;
-  await groupAdmin.save();
+  await getManager().transaction(async manager => {
 
-  await generateOrg(1, groupAdmin, 5, 20);
-  await generateOrg(2, groupAdmin, 5, 20);
+    // Create Group Admin
+    let groupAdmin = manager.create(User, {
+      edipi: '0000000001',
+      firstName: 'Group',
+      lastName: 'Admin',
+      phone: '123-456-7890',
+      email: 'groupadmin@statusengine.com',
+      service: 'Space Force',
+      isRegistered: true,
+    });
+    groupAdmin = await manager.save(groupAdmin);
+
+    // Create Org 1 & 2 and their Users
+    await generateOrg(manager, 1, groupAdmin, 5, 20);
+    await generateOrg(manager, 2, groupAdmin, 5, 20);
+  });
 
   await connection.close();
   console.log('Finished!');
 }());
 
-async function generateOrg(orgNum: number, admin: User, numUsers: number, numRosterEntries: number) {
-  const org = new Org();
-  org.name = `Test Group ${orgNum}`;
-  org.description = `Group ${orgNum} for testing.`;
-  org.contact = admin;
-  org.indexPrefix = `testgroup${orgNum}`;
-  org.defaultMusterConfiguration = [];
-  await org.save();
 
-  const customColumn = new CustomRosterColumn();
-  customColumn.org = org;
-  customColumn.name = 'myCustomColumn';
-  customColumn.display = 'My Custom Column';
-  customColumn.type = RosterColumnType.String;
-  customColumn.phi = false;
-  customColumn.pii = false;
-  customColumn.required = false;
-  await customColumn.save();
+async function generateOrg(manager: EntityManager, orgNum: number, admin: User, numUsers: number, numRosterEntries: number) {
+  let org = manager.create(Org, {
+    name: `Test Group ${orgNum}`,
+    description: `Group ${orgNum} for testing.`,
+    contact: admin,
+    indexPrefix: `testgroup${orgNum}`,
+    defaultMusterConfiguration: [],
+  });
+  org = await manager.save(org);
 
-  const groupAdminRole = await createGroupAdminRole(org).save();
-  if (admin.roles) {
-    admin.roles.push(groupAdminRole);
-  } else {
-    admin.roles = [groupAdminRole];
-  }
-  await admin.save();
+  let customColumn = manager.create(CustomRosterColumn, {
+    org,
+    name: 'myCustomColumn',
+    display: `My Custom Column : Group ${orgNum}`,
+    type: RosterColumnType.String,
+    phi: false,
+    pii: false,
+    required: false,
+  });
+  customColumn = await manager.save(customColumn);
 
-  let userRole = createUserRole(org);
-  userRole.allowedRosterColumns.push(customColumn.name);
-  userRole = await userRole.save();
+  let groupAdminRole = createGroupAdminRole(manager, org);
+  groupAdminRole = await manager.save(groupAdminRole);
+  await admin.addRole(manager, groupAdminRole, '*');
+  admin = await manager.save(admin);
+
+  let groupUserRole = createGroupUserRole(manager, org);
+  groupUserRole.allowedRosterColumns.push(customColumn.name);
+  groupUserRole = await manager.save(groupUserRole);
 
   for (let i = 0; i < numUsers; i++) {
-    const user = new User();
-    user.edipi = `${orgNum}00000000${i}`;
-    user.firstName = 'User';
-    user.lastName = `${i}`;
-    user.phone = randomPhoneNumber();
-    user.email = `user${i}@org${orgNum}.com`;
-    user.service = 'Space Force';
-    user.roles = [userRole];
-    user.isRegistered = true;
-    await user.save();
+    let user = manager.create(User, {
+      edipi: `${orgNum}00000000${i}`,
+      firstName: 'User',
+      lastName: `${i}`,
+      phone: randomPhoneNumber(),
+      email: `user${i}@org${orgNum}.com`,
+      service: 'Space Force',
+      isRegistered: true,
+    });
+    user = await manager.save(user);
+    await user.addRole(manager, groupUserRole, 'unit1');
   }
 
   const units: Unit[] = [];
   for (let i = 1; i <= 5; i++) {
-    const unit = new Unit();
-    unit.org = org;
-    unit.name = `Unit ${i}`;
-    unit.id = `unit${i}`;
-    unit.musterConfiguration = [];
-    units.push(await unit.save());
+    let unit = manager.create(Unit, {
+      org,
+      name: `Unit ${i} : Group ${orgNum}`,
+      id: `unit${i}`,
+      musterConfiguration: [],
+    });
+    unit = await manager.save(unit);
+    units.push(unit);
   }
 
   for (let i = 0; i < numRosterEntries; i++) {
-    const rosterEntry = new Roster();
-    rosterEntry.edipi = `${orgNum}${`${i}`.padStart(9, '0')}`;
-    rosterEntry.firstName = 'Roster';
-    rosterEntry.lastName = `Entry${i}`;
-    // Ensure at least some roster entries are in unit 1.
-    rosterEntry.unit = (i % 2 === 0) ? units[0] : units[randomNumber(1, 4)];
     const customColumns: any = {};
     customColumns[customColumn.name] = `custom column value`;
-    rosterEntry.customColumns = customColumns;
-    await rosterEntry.save();
+    const rosterEntry = manager.create(Roster, {
+      edipi: `${orgNum}${`${i}`.padStart(9, '0')}`,
+      firstName: 'Roster',
+      lastName: `Entry${i}`,
+      unit: (i % 2 === 0) ? units[0] : units[randomNumber(1, 4)], // Ensure at least some roster entries are in unit 1.
+      customColumns,
+    });
+    await manager.save(rosterEntry);
   }
 
   return org;
@@ -114,35 +125,37 @@ function randomNumber(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-function createGroupAdminRole(org: Org, workspace?: Workspace) {
-  const role = new Role();
-  role.name = 'Group Admin';
-  role.description = 'For managing the group.';
-  role.org = org;
-  role.indexPrefix = '*';
-  role.allowedRosterColumns = ['*'];
-  role.allowedNotificationEvents = ['*'];
-  role.canManageGroup = true;
-  role.canManageRoster = true;
-  role.canManageWorkspace = true;
-  role.canViewMuster = true;
-  role.canViewPII = true;
-  role.canViewRoster = true;
-  role.workspace = workspace;
+function createGroupAdminRole(manager: EntityManager, org: Org, workspace?: Workspace) {
+  const role = manager.create(Role, {
+    name: `Group Admin : Group ${org.id}`,
+    description: 'For managing the group.',
+    org,
+    defaultIndexPrefix: '*',
+    allowedRosterColumns: ['*'],
+    allowedNotificationEvents: ['*'],
+    canManageGroup: true,
+    canManageRoster: true,
+    canManageWorkspace: true,
+    canViewMuster: true,
+    canViewPII: true,
+    canViewRoster: true,
+    workspace,
+  });
   return role;
 }
 
-function createUserRole(org: Org, workspace?: Workspace) {
-  const role = new Role();
-  role.name = 'Group User';
-  role.description = 'Basic role for all group users.';
-  role.org = org;
-  role.indexPrefix = 'unit1';
-  role.allowedRosterColumns = ['edipi', 'firstName', 'lastName'];
-  role.allowedNotificationEvents = [];
-  role.canManageRoster = true;
-  role.canViewRoster = true;
-  role.canViewMuster = true;
-  role.workspace = workspace;
+function createGroupUserRole(manager: EntityManager, org: Org, workspace?: Workspace) {
+  const role = manager.create(Role, {
+    name: `Group User : Group ${org.id}`,
+    description: `Basic role for all Group ${org.id} users.`,
+    org,
+    defaultIndexPrefix: 'unit1',
+    allowedRosterColumns: ['edipi', 'firstName', 'lastName'],
+    allowedNotificationEvents: [],
+    canManageRoster: true,
+    canViewRoster: true,
+    canViewMuster: true,
+    workspace,
+  });
   return role;
 }

--- a/server/util/muster-utils.ts
+++ b/server/util/muster-utils.ts
@@ -5,7 +5,7 @@ import {
 import moment from 'moment-timezone';
 import { Like } from 'typeorm';
 import { Org } from '../api/org/org.model';
-import { Role } from '../api/role/role.model';
+import { UserRole } from '../api/user/user-role.model';
 import { Roster } from '../api/roster/roster.model';
 import {
   MusterConfiguration,
@@ -26,18 +26,18 @@ import {
  */
 export async function getRosterMusterStats(args: {
   org: Org
-  role: Role
+  userRole: UserRole
   interval: TimeInterval
   intervalCount: number
   unitId?: string
 }) {
-  const { org, role, interval, intervalCount, unitId } = args;
+  const { org, userRole, interval, intervalCount, unitId } = args;
 
   // Send ES request.
   let response: SearchResponse<never>;
   try {
     response = await elasticsearch.search({
-      index: role.getKibanaIndexForMuster(unitId),
+      index: userRole.getKibanaIndexForMuster(unitId),
       body: buildIndividualsMusterBody({
         interval,
         intervalCount,
@@ -72,7 +72,7 @@ export async function getRosterMusterStats(args: {
     rosterEntriesByEdipi[e.edipi] = e;
   });
 
-  const allowedRosterColumns = await Roster.getAllowedColumns(org, role);
+  const allowedRosterColumns = await Roster.getAllowedColumns(org, userRole.role);
 
   // Collect reports and reports missed.
   const individualStats: IndividualStats = {};
@@ -151,17 +151,17 @@ export async function getRosterMusterStats(args: {
  * Get aggregated unit muster stats over the given weeks/months.
  */
 export async function getUnitMusterStats(args: {
-  role: Role
+  userRole: UserRole
   weeksCount: number
   monthsCount: number
 }) {
-  const { role, weeksCount, monthsCount } = args;
+  const { userRole, weeksCount, monthsCount } = args;
 
   // Get unit names.
-  const unitIdFilter = role.getUnitFilter().replace('*', '%');
+  const unitIdFilter = userRole.getUnitFilter().replace('*', '%');
   const units = await Unit.find({
     where: {
-      org: role.org,
+      org: userRole.role.org,
       id: Like(unitIdFilter),
     },
   });
@@ -171,7 +171,7 @@ export async function getUnitMusterStats(args: {
   //
   // Build elastcisearch multisearch queries.
   //
-  const index = role.getKibanaIndexForMuster();
+  const index = userRole.getKibanaIndexForMuster();
   const esBody = [
     { index },
     buildMusterEsBody({

--- a/src/actions/roster.actions.ts
+++ b/src/actions/roster.actions.ts
@@ -58,7 +58,7 @@ export namespace Roster {
     console.log('file', file);
 
     const appState = getState();
-    const orgId = appState.user.activeRole?.org?.id;
+    const orgId = appState.user.activeRole?.role.org?.id;
 
     if (!appState.user.activeRole || !orgId) {
       console.log('User has no active role for orgId, cannot upload roster.');

--- a/src/components/app-sidenav/app-sidenav.tsx
+++ b/src/components/app-sidenav/app-sidenav.tsx
@@ -115,28 +115,28 @@ export const AppSidenav = () => {
             name="Home"
             icon={(<HomeIcon />)}
           />
-          {user.activeRole?.workspace && (
+          {user.activeRole?.role.workspace && (
             <SidenavLink
               href={`/dashboard?orgId=${orgId}`}
               name="Analytics"
               icon={(<BarChartIcon />)}
             />
           )}
-          {user.activeRole?.workspace && (
+          {user.activeRole?.role.workspace && (
             <SidenavLink
               to="/data-export"
               name="Data Export"
               icon={(<DataExportIcon />)}
             />
           )}
-          {user.activeRole?.canViewMuster && (
+          {user.activeRole?.role.canViewMuster && (
             <SidenavLink
               to="/muster"
               name="Muster"
               icon={(<PersonCheckIcon />)}
             />
           )}
-          {user.activeRole?.canViewRoster && (
+          {user.activeRole?.role.canViewRoster && (
             <SidenavLink
               to="/roster"
               name="Roster"
@@ -145,7 +145,7 @@ export const AppSidenav = () => {
           )}
         </List>
 
-        {user.activeRole?.canManageGroup && (
+        {user.activeRole?.role.canManageGroup && (
           <>
             <div className={clsx(classes.header, {
               [classes.headerExpanded]: appFrame.sidenavExpanded,

--- a/src/components/app-toolbar/app-toolbar.tsx
+++ b/src/components/app-toolbar/app-toolbar.tsx
@@ -40,7 +40,7 @@ export const AppToolbar = () => {
         <Toolbar className={classes.toolbar}>
           <img className={classes.logo} src={logoImage} alt="StatusEngine Logo" height="35" />
           <div className={classes.spacer} />
-          {user.activeRole && user.roles && (
+          {user.activeRole && user.userRoles && (
             <>
               <Button
                 className={classes.toolbarButton}
@@ -48,7 +48,7 @@ export const AppToolbar = () => {
                 onClick={e => setOrgMenuAnchor(e.currentTarget)}
                 endIcon={<ArrowDropDown />}
               >
-                {`${user.activeRole.org?.name}`}
+                {`${user.activeRole.role.org?.name}`}
               </Button>
               <Menu
                 open={Boolean(orgMenuAnchor)}
@@ -59,13 +59,13 @@ export const AppToolbar = () => {
                 transformOrigin={{ vertical: 'top', horizontal: 'right' }}
                 className={classes.toolbarMenu}
               >
-                {user.roles.map(role => (
+                {user.userRoles.map(userRole => (
                   <MenuItem
-                    key={role.id}
-                    selected={user.activeRole!.org!.id === role.org!.id}
-                    onClick={handleOrgChanged(role.org!.id)}
+                    key={userRole.role.id}
+                    selected={user.activeRole!.role.org!.id === userRole.role.org!.id}
+                    onClick={handleOrgChanged(userRole.role.org!.id)}
                   >
-                    {role.org!.name}
+                    {userRole.role.org!.name}
                   </MenuItem>
                 ))}
                 <Divider />

--- a/src/components/pages/groups-page/groups-page.tsx
+++ b/src/components/pages/groups-page/groups-page.tsx
@@ -93,8 +93,8 @@ export const GroupsPage = () => {
       return org.accessRequest.status;
     }
 
-    const role = user.roles!.find(r => r.org!.id === org.id);
-    return role!.name;
+    const userRole = user.userRoles!.find(ur => ur.role.org!.id === org.id);
+    return userRole?.role!.name;
   }
 
   function getStatusColor(org: MyOrg) {
@@ -114,10 +114,10 @@ export const GroupsPage = () => {
 
   function getMyOrgs() {
     // Build list of orgs we're in or have made access requests to.
-    const userOrgs = user.roles!.map(role => ({
-      id: role.org!.id,
-      name: role.org!.name,
-      contact: role.org!.contact,
+    const userOrgs = user.userRoles!.map(userRole => ({
+      id: userRole.role.org!.id,
+      name: userRole.role.org!.name,
+      contact: userRole.role.org!.contact,
     })) as MyOrg[];
 
     const accessReqs = accessRequests.map(req => ({
@@ -172,9 +172,10 @@ export const GroupsPage = () => {
     }
 
     // Filter orgs that we're already in.
-    const userRoles = user.roles || [];
-    for (const role of userRoles) {
-      myOrgsLookup[role.org!.id] = true;
+    if (user.userRoles) {
+      for (const userRole of user.userRoles) {
+        myOrgsLookup[userRole.role.org!.id] = true;
+      }
     }
 
     setRequestAccessOrgs(

--- a/src/components/pages/home-page/home-page.tsx
+++ b/src/components/pages/home-page/home-page.tsx
@@ -36,7 +36,7 @@ export const HomePage = () => {
                     </Typography>
 
                     <ul>
-                      {user.activeRole?.canViewRoster && (
+                      {user.activeRole?.role.canViewRoster && (
                         <li>
                           <Typography>
                             <strong><Link to="/roster">Roster Management</Link></strong><br />
@@ -45,7 +45,7 @@ export const HomePage = () => {
                           </Typography>
                         </li>
                       )}
-                      {user.activeRole?.canViewMuster && (
+                      {user.activeRole?.role.canViewMuster && (
                         <li>
                           <Typography>
                             <strong><Link to="/muster">Muster Snapshot</Link></strong><br />
@@ -54,7 +54,7 @@ export const HomePage = () => {
                           </Typography>
                         </li>
                       )}
-                      {user.activeRole?.workspace && (
+                      {user.activeRole?.role.workspace && (
                         <li>
                           <Typography>
                             <strong><Link href={`/dashboard?orgId=${orgId}`}>Customizable Dashboards</Link></strong><br />

--- a/src/components/pages/muster-page/muster-page.tsx
+++ b/src/components/pages/muster-page/muster-page.tsx
@@ -46,6 +46,7 @@ import { Unit } from '../../../actions/unit.actions';
 import { DataExportIcon } from '../../icons/data-export-icon';
 import { Modal } from '../../../actions/modal.actions';
 import { formatMessage } from '../../../utility/errors';
+import { UserSelector } from '../../../selectors/user.selector';
 
 interface TimeRange {
   interval: 'day' | 'hour'
@@ -68,7 +69,7 @@ export const MusterPage = () => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const units = useSelector(UnitSelector.all);
-  const user = useSelector((state: AppState) => state.user);
+  const user = useSelector<AppState, UserState>(state => state.user);
 
   const maxNumColumnsToShow = 6;
   const maxTopUnitsCount = 5;
@@ -123,8 +124,9 @@ export const MusterPage = () => {
   const [monthlyTrendData, setMonthlyTrendData] = useState<Plotly.Data[]>([]);
   const [individualsData, setIndividualsData] = useState<ApiMusterIndividuals>({ rows: [], totalRowsCount: 0 });
 
-  const orgId = useSelector<AppState, UserState>(state => state.user).activeRole!.org!.id;
-  const orgName = useSelector<AppState, UserState>(state => state.user).activeRole!.org!.name;
+  const org = useSelector(UserSelector.org);
+  const orgId = org?.id;
+  const orgName = org?.name;
   const isPageLoading = useSelector<AppState, boolean>(state => state.appFrame.isPageLoading);
 
   //
@@ -381,7 +383,7 @@ export const MusterPage = () => {
 
         <Grid container spacing={3}>
           {/* Table */}
-          {user.activeRole?.canViewPII && (
+          {user.activeRole?.role.canViewPII && (
             <Grid item xs={12}>
               <Paper>
                 <TableContainer>

--- a/src/components/pages/role-management-page/edit-role-dialog.tsx
+++ b/src/components/pages/role-management-page/edit-role-dialog.tsx
@@ -47,7 +47,7 @@ export const EditRoleDialog = (props: EditRoleDialogProps) => {
   const existingRole: boolean = !!role;
   const [name, setName] = useState(role?.name || '');
   const [description, setDescription] = useState(role?.description || '');
-  const [indexPrefix, setIndexPrefix] = useState(role?.indexPrefix || '');
+  const [defaultIndexPrefix, setDefaultIndexPrefix] = useState(role?.defaultIndexPrefix || '');
   const [workspaceId, setWorkspaceId] = useState(role?.workspace?.id || -1);
   const [allowedRosterColumns, setAllowedRosterColumns] = useState(parsePermissions(rosterColumns || [], role?.allowedRosterColumns));
   const [allowedNotificationEvents, setAllowedNotificationEvents] = useState(parsePermissions(notifications?.map(notification => {
@@ -132,7 +132,7 @@ export const EditRoleDialog = (props: EditRoleDialogProps) => {
     const body = {
       name,
       description,
-      indexPrefix,
+      defaultIndexPrefix,
       workspaceId: workspaceId < 0 ? null : workspaceId,
       allowedRosterColumns: permissionsToArray(allowedColumns),
       allowedNotificationEvents: permissionsToArray(allowedNotificationEvents),
@@ -259,13 +259,13 @@ export const EditRoleDialog = (props: EditRoleDialogProps) => {
             <Typography className={classes.workspaceDescription}>{getWorkspaceDescription()}</Typography>
           </Grid>
           <Grid item xs={6}>
-            <Typography className={classes.roleHeader}>Unit Filter:</Typography>
+            <Typography className={classes.roleHeader}>Default Unit Filter:</Typography>
             <TextField
               className={classes.textField}
               id="role-index-prefix"
               disabled={formDisabled}
-              value={indexPrefix}
-              onChange={onInputChanged(setIndexPrefix)}
+              value={defaultIndexPrefix}
+              onChange={onInputChanged(setDefaultIndexPrefix)}
             />
           </Grid>
           <Grid item xs={6}>

--- a/src/components/pages/role-management-page/role-management-page.tsx
+++ b/src/components/pages/role-management-page/role-management-page.tsx
@@ -115,7 +115,7 @@ export const RoleManagementPage = () => {
         </ButtonSet>
         <div className={classes.accordionHeader}>
           <Typography>Role Name</Typography>
-          <Typography>Unit Filter</Typography>
+          <Typography>Default Unit Filter</Typography>
           <Typography>Analytics Workspace</Typography>
         </div>
         {roles.map((row, index) => (
@@ -130,7 +130,7 @@ export const RoleManagementPage = () => {
               id={`role${row.id}_header`}
             >
               <Typography className={classes.nameColumn}>{row.name}</Typography>
-              <Typography className={classes.indexPrefixColumn}>{row.indexPrefix}</Typography>
+              <Typography className={classes.indexPrefixColumn}>{row.defaultIndexPrefix}</Typography>
               <Typography>{row.workspace ? row.workspace.name : 'None'}</Typography>
             </AccordionSummary>
             <AccordionDetails>

--- a/src/components/pages/roster-columns-page/roster-columns-page.tsx
+++ b/src/components/pages/roster-columns-page/roster-columns-page.tsx
@@ -24,14 +24,13 @@ import AddCircleIcon from '@material-ui/icons/AddCircle';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import PageHeader from '../../page-header/page-header';
 import useStyles from './roster-columns-page.styles';
-import { UserState } from '../../../reducers/user.reducer';
-import { AppState } from '../../../store';
 import { ApiRosterColumnInfo, rosterColumnTypeDisplayName } from '../../../models/api-response';
 import { EditColumnDialog, EditColumnDialogProps } from './edit-column-dialog';
 import { AppFrame } from '../../../actions/app-frame.actions';
 import { ButtonSet } from '../../buttons/button-set';
 import { Modal } from '../../../actions/modal.actions';
 import { formatMessage } from '../../../utility/errors';
+import { UserSelector } from '../../../selectors/user.selector';
 
 interface ColumnMenuState {
   anchor: HTMLElement | null,
@@ -47,7 +46,7 @@ export const RosterColumnsPage = () => {
   const [editColumnDialogProps, setEditColumnDialogProps] = useState<EditColumnDialogProps>({ open: false });
   const [columnMenu, setColumnMenu] = React.useState<ColumnMenuState>({ anchor: null });
 
-  const orgId = useSelector<AppState, UserState>(state => state.user).activeRole?.org?.id;
+  const orgId = useSelector(UserSelector.orgId);
 
   const initializeTable = React.useCallback(async () => {
     dispatch(AppFrame.setPageLoading(true));

--- a/src/components/pages/roster-page/roster-page.tsx
+++ b/src/components/pages/roster-page/roster-page.tsx
@@ -34,8 +34,6 @@ import PageHeader from '../../page-header/page-header';
 import { SortDirection, TableColumn, TableCustomColumnsContent } from '../../tables/table-custom-columns-content';
 import { TablePagination } from '../../tables/table-pagination/table-pagination';
 import useStyles from './roster-page.styles';
-import { UserState } from '../../../reducers/user.reducer';
-import { AppState } from '../../../store';
 import {
   ApiRosterColumnInfo,
   ApiRosterColumnType,
@@ -54,6 +52,7 @@ import { formatMessage } from '../../../utility/errors';
 import { ButtonSet } from '../../buttons/button-set';
 import { DataExportIcon } from '../../icons/data-export-icon';
 import { Modal } from '../../../actions/modal.actions';
+import { UserSelector } from '../../../selectors/user.selector';
 
 const unitColumn: ApiRosterColumnInfo = {
   name: 'unit',
@@ -102,8 +101,9 @@ export const RosterPage = () => {
   const [visibleColumnsMenuOpen, setVisibleColumnsMenuOpen] = useState(false);
   const [applyingFilters, setApplyingFilters] = useState(false);
   const visibleColumnsButtonRef = useRef<HTMLDivElement>(null);
-  const orgId = useSelector<AppState, UserState>(state => state.user).activeRole?.org?.id;
-  const orgName = useSelector<AppState, UserState>(state => state.user).activeRole?.org?.name;
+  const org = useSelector(UserSelector.org);
+  const orgId = org?.id;
+  const orgName = org?.name;
 
   //
   // Effects

--- a/src/components/pages/settings-page/notifications-tab.tsx
+++ b/src/components/pages/settings-page/notifications-tab.tsx
@@ -7,12 +7,11 @@ import {
 import { HelpOutline } from '@material-ui/icons';
 import { ApiNotification, ApiUserNotificationSetting } from '../../../models/api-response';
 import useStyles from './notifications-tab.style';
-import { AppState } from '../../../store';
-import { UserState } from '../../../reducers/user.reducer';
 import { TabPanelProps } from './settings-page';
 import { EditAlertDialog, EditAlertDialogProps } from './edit-alert-dialog';
 import { Modal } from '../../../actions/modal.actions';
 import { formatMessage } from '../../../utility/errors';
+import { UserSelector } from '../../../selectors/user.selector';
 
 interface NotificationSettings {
   [key: string]: ApiUserNotificationSetting,
@@ -34,7 +33,7 @@ export const NotificationsTab = (props: TabPanelProps) => {
   const [notifications, setNotifications] = useState<ApiNotification[]>([]);
   const [editAlertDialogProps, setEditAlertDialogProps] = useState<EditAlertDialogProps>({ open: false });
 
-  const orgId = useSelector<AppState, UserState>(state => state.user).activeRole?.org?.id;
+  const orgId = useSelector(UserSelector.orgId);
 
   const initializeTable = React.useCallback(async () => {
     const notificationsResponse = (await axios.get(`api/notification/${orgId}`)).data as ApiNotification[];

--- a/src/components/pages/units-page/default-muster-dialog.tsx
+++ b/src/components/pages/units-page/default-muster-dialog.tsx
@@ -31,8 +31,7 @@ import { MusterConfiguration } from '../../../models/api-response';
 import {
   dayIsIn, DaysOfTheWeek, nextDay, oneDaySeconds,
 } from '../../../utility/days';
-import { AppState } from '../../../store';
-import { UserState } from '../../../reducers/user.reducer';
+import { UserSelector } from '../../../selectors/user.selector';
 
 export interface DefaultMusterDialogProps {
   open: boolean,
@@ -54,7 +53,7 @@ interface MusterWindow {
 export const DefaultMusterDialog = (props: DefaultMusterDialogProps) => {
   const classes = useStyles();
   const [formDisabled, setFormDisabled] = useState(false);
-  const org = useSelector<AppState, UserState>(state => state.user).activeRole?.org;
+  const org = useSelector(UserSelector.org);
   const orgId = org?.id;
   const defaultMusterConfiguration = org?.defaultMusterConfiguration;
   const {

--- a/src/components/pages/units-page/units-page.tsx
+++ b/src/components/pages/units-page/units-page.tsx
@@ -29,8 +29,6 @@ import AddCircleIcon from '@material-ui/icons/AddCircle';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import useStyles from './units-page.styles';
-import { UserState } from '../../../reducers/user.reducer';
-import { AppState } from '../../../store';
 import { ApiUnit, MusterConfiguration } from '../../../models/api-response';
 import { EditUnitDialog, EditUnitDialogProps } from './edit-unit-dialog';
 import { UnitSelector } from '../../../selectors/unit.selector';
@@ -41,6 +39,7 @@ import { Modal } from '../../../actions/modal.actions';
 import { formatMessage } from '../../../utility/errors';
 import { DefaultMusterDialog, DefaultMusterDialogProps } from './default-muster-dialog';
 import { User } from '../../../actions/user.actions';
+import { UserSelector } from '../../../selectors/user.selector';
 
 interface UnitMenuState {
   anchor: HTMLElement | null,
@@ -57,7 +56,7 @@ export const UnitsPage = () => {
   const [unitMenu, setUnitMenu] = React.useState<UnitMenuState>({ anchor: null });
   const [defaultMusterSaved, setDefaultMusterSaved] = React.useState(false);
 
-  const org = useSelector<AppState, UserState>(state => state.user).activeRole?.org;
+  const org = useSelector(UserSelector.org);
   const orgId = org?.id;
   const defaultMusterConfiguration = org?.defaultMusterConfiguration ?? [];
 

--- a/src/components/pages/users-page/select-role-dialog.tsx
+++ b/src/components/pages/users-page/select-role-dialog.tsx
@@ -43,7 +43,7 @@ const SelectRoleDialog: React.FunctionComponent<SelectRoleDialogProps> = (props:
 
   useEffect(() => {
     if (availableRoles!.length > 0) {
-      const roleId = user?.roles?.length ? user?.roles[0].id : availableRoles[0].id;
+      const roleId = user?.userRoles?.length ? user?.userRoles[0].role.id : availableRoles[0].id;
       const roleIndex = availableRoles.findIndex(role => role.id === roleId);
       setSelectedRoleIndex(roleIndex >= 0 ? roleIndex : 0);
     }
@@ -103,7 +103,7 @@ const SelectRoleDialog: React.FunctionComponent<SelectRoleDialogProps> = (props:
         </Button>
         <ButtonWithSpinner
           onClick={() => onChange(selectedRole)}
-          disabled={(user?.roles ?? []).some(role => role.id === selectedRole.id)}
+          disabled={(user?.userRoles ?? []).some(userRole => userRole.role.id === selectedRole.id)}
           color="primary"
           loading={loading}
         >

--- a/src/components/pages/users-page/users-page.tsx
+++ b/src/components/pages/users-page/users-page.tsx
@@ -295,7 +295,7 @@ export const UsersPage = () => {
                     </IconButton>
                   </TableCell>
                   <TableCell>{row.phone}</TableCell>
-                  <TableCell>{row.roles ? row.roles[0].name : 'Unknown'}</TableCell>
+                  <TableCell>{row.userRoles?.length ? row.userRoles[0].role.name : 'Unknown'}</TableCell>
                   <TableCell align="right" padding="none" size="small">
                     <IconButton
                       aria-label="more"

--- a/src/components/pages/workspaces-page/workspaces-page.tsx
+++ b/src/components/pages/workspaces-page/workspaces-page.tsx
@@ -17,13 +17,12 @@ import CheckIcon from '@material-ui/icons/Check';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import PageHeader from '../../page-header/page-header';
 import useStyles from './workspaces-page.styles';
-import { UserState } from '../../../reducers/user.reducer';
-import { AppState } from '../../../store';
 import { ApiWorkspace, ApiWorkspaceTemplate } from '../../../models/api-response';
 import { EditWorkspaceDialog, EditWorkspaceDialogProps } from './edit-workspace-dialog';
 import { ButtonSet } from '../../buttons/button-set';
 import { Modal } from '../../../actions/modal.actions';
 import { formatMessage } from '../../../utility/errors';
+import { UserSelector } from '../../../selectors/user.selector';
 
 interface WorkspaceMenuState {
   anchor: HTMLElement | null,
@@ -39,7 +38,7 @@ export const WorkspacesPage = () => {
   const [editWorkspaceDialogProps, setEditWorkspaceDialogProps] = useState<EditWorkspaceDialogProps>({ open: false });
   const [workspaceMenu, setWorkspaceMenu] = React.useState<WorkspaceMenuState>({ anchor: null });
 
-  const orgId = useSelector<AppState, UserState>(state => state.user).activeRole?.org?.id;
+  const orgId = useSelector(UserSelector.orgId);
 
   const initializeTable = React.useCallback(async () => {
     const ws = (await axios.get(`api/workspace/${orgId}`)).data as ApiWorkspace[];

--- a/src/components/role-info-panel/role-info-panel.tsx
+++ b/src/components/role-info-panel/role-info-panel.tsx
@@ -97,7 +97,7 @@ const RoleInfoPanel = (props: RoleInfoPanelProps) => {
     <NegativeMarginScrollFix spacing={scrollFix ? gridSpacing : 0}>
       <Grid container spacing={gridSpacing}>
         <TextSection full={hideUnitFilter} text={role.description} title="Description" />
-        <TextSection text={role.indexPrefix} title="Unit Filter" visible={!hideUnitFilter} />
+        <TextSection text={role.defaultIndexPrefix} title="Default Unit Filter" visible={!hideUnitFilter} />
         <Grid item container xs={6}>
           <TextSection
             full

--- a/src/models/api-response.ts
+++ b/src/models/api-response.ts
@@ -20,7 +20,7 @@ export interface ApiRole {
   workspace?: ApiWorkspace,
   name: string,
   description: string,
-  indexPrefix: string,
+  defaultIndexPrefix: string,
   allowedRosterColumns: string[],
   allowedNotificationEvents: string[],
   canManageGroup: boolean,
@@ -32,6 +32,13 @@ export interface ApiRole {
   canViewPHI: boolean,
 }
 
+export interface ApiUserRole {
+  id: number,
+  indexPrefix: string,
+  role: ApiRole,
+  user: ApiUser,
+}
+
 export interface ApiUser {
   edipi: string,
   firstName: string,
@@ -39,7 +46,7 @@ export interface ApiUser {
   service: string,
   phone: string,
   email: string,
-  roles?: ApiRole[],
+  userRoles?: ApiUserRole[],
   rootAdmin: boolean,
   isRegistered: boolean,
 }

--- a/src/reducers/local-storage.reducer.ts
+++ b/src/reducers/local-storage.reducer.ts
@@ -17,7 +17,7 @@ export function localStorageReducer(state = localStorageInitialState, action: an
       const loggedInState = getLoggedInState(userData, localStorage);
       return {
         ...state,
-        orgId: loggedInState.activeRole?.org?.id,
+        orgId: loggedInState.activeRole?.role.org?.id,
       };
     }
     case User.Actions.Login.type: {
@@ -25,7 +25,7 @@ export function localStorageReducer(state = localStorageInitialState, action: an
       const loggedInState = getLoggedInState(userData, localStorage);
       return {
         ...state,
-        orgId: loggedInState.activeRole?.org?.id,
+        orgId: loggedInState.activeRole?.role.org?.id,
       };
     }
     case User.Actions.Logout.type: {

--- a/src/reducers/user.reducer.ts
+++ b/src/reducers/user.reducer.ts
@@ -1,9 +1,9 @@
 import { User } from '../actions/user.actions';
-import { ApiRole, ApiUser } from '../models/api-response';
+import { ApiUser, ApiUserRole } from '../models/api-response';
 import { getLoggedInState } from '../utility/user-utils';
 
 export interface UserState extends ApiUser {
-  activeRole?: ApiRole
+  activeRole?: ApiUserRole
   isLoggedIn: boolean
 }
 
@@ -16,7 +16,7 @@ export const userInitialState: UserState = {
   email: '',
   rootAdmin: false,
   isRegistered: false,
-  roles: [],
+  userRoles: [],
   isLoggedIn: false,
 };
 
@@ -42,10 +42,10 @@ export function userReducer(state = userInitialState, action: any): UserState {
       return userInitialState;
     case User.Actions.ChangeOrg.type: {
       const orgId = (action as User.Actions.ChangeOrg).payload.orgId;
-      const activeRole = state.roles?.find(role => role.org?.id === orgId);
+      const userRole = state.userRoles?.find(ur => ur.role.org?.id === orgId);
       return {
         ...state,
-        activeRole,
+        activeRole: userRole,
       };
     }
     default:

--- a/src/selectors/user.selector.ts
+++ b/src/selectors/user.selector.ts
@@ -2,6 +2,6 @@ import { AppState } from '../store';
 
 export namespace UserSelector {
   export const current = (state: AppState) => state.user;
-  export const orgId = (state: AppState) => state.user.activeRole?.org?.id;
-  export const org = (state: AppState) => state.user.activeRole?.org;
+  export const orgId = (state: AppState) => state.user.activeRole?.role.org?.id;
+  export const org = (state: AppState) => state.user.activeRole?.role.org;
 }

--- a/src/utility/user-utils.ts
+++ b/src/utility/user-utils.ts
@@ -3,12 +3,12 @@ import { LocalStorageState } from '../reducers/local-storage.reducer';
 import { UserState } from '../reducers/user.reducer';
 
 export function getLoggedInState(user: ApiUser, localStorage: LocalStorageState): Partial<UserState> {
-  const roles = user.roles ?? [];
-  const restoredActiveRole = roles?.find(role => role.org?.id === localStorage.orgId);
+  const userRoles = user.userRoles ?? [];
+  const restoredActiveRole = userRoles.find(ur => ur.role.org?.id === localStorage.orgId);
   return {
     ...user,
-    roles,
-    activeRole: restoredActiveRole ?? roles[0],
+    userRoles,
+    activeRole: restoredActiveRole ?? userRoles[0],
     isLoggedIn: true,
   };
 }


### PR DESCRIPTION
# Summary of changes

This PR implements the requirements for [Separate Unit From Role (Implementation)](https://app.asana.com/0/1188940305683068/1199542992771591). 


## List of changes

### API Server Changes

- Added migration 1610729959726-SeparateUnitFromRole.ts
  - Renames `role.index_prefix` to `role.default_index_prefix`
  - Creates new `user_role` table with `index_prefix` column
  - Copies data from old `user_roles` table to new `user_role` table
  - Drops old `user_roles` table
- Added new `UserRole` Entity
  - Moved the following methods from `Role` to `UserRole`
    - `getUnitFilter`
    - `getKibanaIndex`
    - `getKibanaIndexForMuster`
    - ` getKibanaUserClaim`
    - `getKibanaRoles`
- Changed `ApiRequest.appRole` to `ApiRequest.appUserRole`
  - Updated all references accordingly
- Added the following methods to the `User` Entity - passing an `EntityManager` to facilitate transactions
  - `async addRole(manager: EntityManager, role: Role, indexPrefix?: string): Promise<User>`
  - `async addRoles(manager: EntityManager, roles: Role[]): Promise<User>`
  - `async removeRole(manager: EntityManager, role?: Role, userRole?: UserRole): Promise<User>`
  - `async changeRole(manager: EntityManager, role: Role, indexPrefix?: string): Promise<User>`

### Web App Changes

- Added new `ApiUserRole` interface
  - Changed `ApiUser.roles?: ApiRole[]` to `ApiUser.userRoles?: ApiUserRole[]`
    - Updated all references accordingly
  - Changed `UserState.activeRole` from `ApiRole` to `ApiUserRole`
    - Updated all references accordingly


Should this pull request be tested any more or less than usual?
---------------------------------------------------------------

Because this PR touches nearly every file, extensive regression testing is required to ensure no functionality was broken.

---

Thank you!