### PR TITLE
Updated for awscliv2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,14 @@ BRANCH=$(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD)
 
 TAG=${BRANCH}-${SHA}-${ENVIRONMENT}
 
-login:  
-	$$(aws ecr get-login --no-include-email)
+login: 
+	aws ecr \
+		get-login-password \
+		--region us-east-1 \
+	| docker login \
+		--username AWS \
+		--password-stdin \
+		508654928277.dkr.ecr.us-east-1.amazonaws.com
 
 build:
 	docker build \


### PR DESCRIPTION
The new Jenkins server has awscli v2. These are the recommended changes per https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-ecr-get-login