### PR TITLE
PR to Fix 500 Error

### DIFF
--- a/server/api/muster/muster.controller.ts
+++ b/server/api/muster/muster.controller.ts
@@ -1,4 +1,5 @@
 import { Response } from 'express';
+import { Brackets } from 'typeorm';
 import { NotFoundError } from '../../util/error-types';
 import {
   buildMusterWindow,
@@ -27,7 +28,6 @@ import {
   assertRequestQuery,
   TimeInterval,
 } from '../../util/util';
-import { Brackets } from 'typeorm';
 
 class MusterController {
 

--- a/server/api/user/user.model.ts
+++ b/server/api/user/user.model.ts
@@ -7,7 +7,7 @@ import { UserRole } from './user-role.model';
 
 @Entity()
 export class User extends BaseEntity {
-  static internalUserEdipi = '_internal_';
+  static internalUserEdipi = 'internal';
 
   @PrimaryColumn({
     length: 10,
@@ -135,6 +135,7 @@ export class User extends BaseEntity {
     internalUser.enabled = true;
     internalUser.isRegistered = true;
     internalUser.rootAdmin = true;
+    internalUser.userRoles = [];
 
     return internalUser;
   }

--- a/server/api/user/user.model.ts
+++ b/server/api/user/user.model.ts
@@ -5,10 +5,9 @@ import { NotFoundError } from '../../util/error-types';
 import { Role } from '../role/role.model';
 import { UserRole } from './user-role.model';
 
-const internalUserEdipi = 'internal';
-
 @Entity()
 export class User extends BaseEntity {
+  static internalUserEdipi = '_internal_';
 
   @PrimaryColumn({
     length: 10,
@@ -120,12 +119,12 @@ export class User extends BaseEntity {
   }
 
   public isInternal() {
-    return this.edipi === internalUserEdipi;
+    return this.edipi === User.internalUserEdipi;
   }
 
   static internal() {
     const internalUser = new User();
-    internalUser.edipi = internalUserEdipi;
+    internalUser.edipi = User.internalUserEdipi;
     internalUser.firstName = 'Internal';
     internalUser.lastName = 'User';
     internalUser.email = 'internal@statusengine.com';

--- a/server/api/user/user.model.ts
+++ b/server/api/user/user.model.ts
@@ -57,7 +57,9 @@ export class User extends BaseEntity {
         indexPrefix: indexPrefix || role.defaultIndexPrefix,
       });
       this.userRoles.push(userRole);
-      await manager.save(userRole);
+      if (this.edipi !== User.internalUserEdipi) {
+        await manager.save(userRole);
+      }
     }
     return this;
   }


### PR DESCRIPTION
The 500 error was introduced when the internal user was being saved instead of staying transient. This PR removes the logic attempting to save the internal user. Also, the `internalUserEdipi` const was changed to a `static` user class variable to eliminate duplication of string literals throughout the code. Finally, the linter complained about the `{ Brackets }` import stating that it needs to happen before the import of error types.

Additional fix for bypassing save on `User.userRoles` if the user is internal.