### PR TITLE
Fix incorrect error when adding individual to roster.

### DIFF
--- a/server/api/roster/roster.controller.ts
+++ b/server/api/roster/roster.controller.ts
@@ -325,15 +325,14 @@ class RosterController {
       throw new NotFoundError(`Unit with ID ${req.body.unit} could not be found.`);
     }
 
-    const rosterEntries = await Roster.find({
-      relations: ['unit'],
+    const rosterEntry = await Roster.findOne({
       where: {
         edipi,
         unit: unit.id,
       },
     });
 
-    if (rosterEntries) {
+    if (rosterEntry) {
       throw new BadRequestError('The individual is already in the roster.');
     }
 


### PR DESCRIPTION
An error was being thrown no matter what when adding an individual, because the check if they existed always evaluated to true.