### PR TITLE
Disable typeorm cache when running tests.

### DIFF
--- a/server/ormconfig.ts
+++ b/server/ormconfig.ts
@@ -40,5 +40,7 @@ export const ormConfig: PostgresConnectionOptions = {
   namingStrategy: new SnakeNamingStrategy(),
   synchronize: (env.isDev && process.env.SYNC_DATABASE === 'true'),
   logging: false,
-  cache: true,
+  cache: (process.env.TYPEORM_CACHE)
+    ? (process.env.TYPEORM_CACHE === 'true')
+    : true,
 };

--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -28,6 +28,7 @@ export SQL_PORT=${SQL_PORT:=5432}
 export SQL_USER=${SQL_USER:=postgres}
 export SQL_PASSWORD=${SQL_PASSWORD:=postgres}
 export PGPASSWORD=$SQL_PASSWORD
+export TYPEORM_CACHE=false
 
 # If the clean flag is passed in, drop the database to start fresh.
 if [ "$CLEAN" == true ]; then


### PR DESCRIPTION
The cache was causing tests to fail when running them frequently.