### PR TITLE
Add support for alternate report types

### DIFF
--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -10,6 +10,7 @@ import accessRequestRoutes from './access-request';
 import workspaceRoutes from './workspace';
 import notificationRoutes from './notification';
 import musterRoutes from './muster';
+import reportRoutes from './report-schema';
 import exportRoutes from './export';
 import { User } from './user/user.model';
 import { Org } from './org/org.model';
@@ -27,6 +28,7 @@ router.use('/access-request', accessRequestRoutes);
 router.use('/workspace', workspaceRoutes);
 router.use('/notification', notificationRoutes);
 router.use('/muster', musterRoutes);
+router.use('/report', reportRoutes);
 router.use('/export', exportRoutes);
 router.use('/reingest', reingestRoutes);
 
@@ -48,6 +50,10 @@ export type OrgPrefixParam = {
 
 export type RoleParam = {
   roleId: string
+};
+
+export type ReportParam = {
+  reportId: string
 };
 
 export type EdipiParam = {
@@ -75,6 +81,7 @@ export type ColumnNameParam = {
 };
 
 export type OrgRoleParams = OrgParam & RoleParam;
+export type OrgReportParams = OrgParam & ReportParam;
 export type OrgEdipiParams = OrgParam & EdipiParam;
 export type OrgRosterParams = OrgParam & RosterParam;
 export type OrgWorkspaceParams = OrgParam & WorkspaceParam;

--- a/server/api/muster/muster.controller.ts
+++ b/server/api/muster/muster.controller.ts
@@ -144,6 +144,9 @@ class MusterController {
     let closestEnd = 0;
 
     for (const muster of musterConfig) {
+      if (muster.reportId !== req.query.reportId) {
+        continue;
+      }
       if (muster.days === DaysOfTheWeek.None) {
         continue;
       }
@@ -209,6 +212,7 @@ type GetClosedMusterWindowsQuery = {
 
 type GetNearestMusterWindowQuery = {
   timestamp: string
+  reportId: string
 };
 
 export default new MusterController();

--- a/server/api/org/org.controller.ts
+++ b/server/api/org/org.controller.ts
@@ -12,7 +12,7 @@ import {
   NotFoundError,
 } from '../../util/error-types';
 import { MusterConfiguration } from '../unit/unit.model';
-import { defaultReportScehmas, ReportSchema } from '../report-schema/report-schema.model';
+import { defaultReportSchemas, ReportSchema } from '../report-schema/report-schema.model';
 
 class OrgController {
 
@@ -61,21 +61,20 @@ class OrgController {
     org.contact = contact;
     org.reportingGroup = req.body.reportingGroup;
 
-    let newOrg = undefined as Org | undefined;
     await getConnection().transaction(async manager => {
-      newOrg = await manager.save(org);
+      await manager.save(org);
 
       // Write default report schemas
-      for (const schema of defaultReportScehmas) {
+      for (const schema of defaultReportSchemas) {
         const reportSchema = ReportSchema.create({
           ...schema,
-          org: newOrg,
+          org,
         });
         await manager.save(reportSchema);
       }
     });
 
-    await res.status(201).json(newOrg);
+    await res.status(201).json(org);
   }
 
   async deleteOrg(req: ApiRequest, res: Response) {

--- a/server/api/org/org.model.mock.ts
+++ b/server/api/org/org.model.mock.ts
@@ -1,6 +1,7 @@
 import { uniqueString } from '../../util/test-utils/unique';
 import { User } from '../user/user.model';
 import { Org } from './org.model';
+import { defaultReportScehmas, ReportSchema } from '../report-schema/report-schema.model';
 
 export function mockOrg(contact: User) {
   return Org.create({
@@ -12,6 +13,12 @@ export function mockOrg(contact: User) {
   });
 }
 
-export function seedOrg(contact: User) {
-  return mockOrg(contact).save();
+export async function seedOrg(contact: User) {
+  const org = await mockOrg(contact).save();
+  const reports = ReportSchema.create(defaultReportScehmas);
+  for (const report of reports) {
+    report.org = org;
+  }
+  await ReportSchema.save(reports);
+  return org;
 }

--- a/server/api/org/org.model.mock.ts
+++ b/server/api/org/org.model.mock.ts
@@ -1,7 +1,7 @@
 import { uniqueString } from '../../util/test-utils/unique';
 import { User } from '../user/user.model';
 import { Org } from './org.model';
-import { defaultReportScehmas, ReportSchema } from '../report-schema/report-schema.model';
+import { defaultReportSchemas, ReportSchema } from '../report-schema/report-schema.model';
 
 export function mockOrg(contact: User) {
   return Org.create({
@@ -15,7 +15,7 @@ export function mockOrg(contact: User) {
 
 export async function seedOrg(contact: User) {
   const org = await mockOrg(contact).save();
-  const reports = ReportSchema.create(defaultReportScehmas);
+  const reports = ReportSchema.create(defaultReportSchemas);
   for (const report of reports) {
     report.org = org;
   }

--- a/server/api/report-schema/index.ts
+++ b/server/api/report-schema/index.ts
@@ -1,0 +1,48 @@
+import bodyParser from 'body-parser';
+import express from 'express';
+import controller from './report-schema.controller';
+import {
+  requireOrgAccess,
+  requireRolePermission,
+} from '../../auth';
+
+const router = express.Router() as any;
+
+router.get(
+  '/:orgId',
+  requireOrgAccess,
+  requireRolePermission(role => role.canManageGroup),
+  controller.getOrgReports,
+);
+
+router.post(
+  '/:orgId',
+  bodyParser.json(),
+  requireOrgAccess,
+  requireRolePermission(role => role.canManageGroup),
+  controller.addReport,
+);
+
+router.get(
+  '/:orgId/:reportId',
+  requireOrgAccess,
+  requireRolePermission(role => role.canManageGroup),
+  controller.getReport,
+);
+
+router.delete(
+  '/:orgId/:reportId',
+  requireOrgAccess,
+  requireRolePermission(role => role.canManageGroup),
+  controller.deleteReport,
+);
+
+router.put(
+  '/:orgId/:reportId',
+  bodyParser.json(),
+  requireOrgAccess,
+  requireRolePermission(role => role.canManageGroup),
+  controller.updateReport,
+);
+
+export default router;

--- a/server/api/report-schema/report-schema.controller.spec.ts
+++ b/server/api/report-schema/report-schema.controller.spec.ts
@@ -10,8 +10,8 @@ import {
 import { Org } from '../org/org.model';
 import { User } from '../user/user.model';
 import { seedReport, seedReports } from './report-schema.model.mock';
-import { defaultReportScehmas, ReportSchema } from './report-schema.model';
-import { ReportBody } from './report-schema.controller';
+import { defaultReportSchemas, ReportSchema } from './report-schema.model';
+import { AddReportBody, UpdateReportBody } from './report-schema.controller';
 
 describe(`Report Schema Controller`, () => {
 
@@ -35,9 +35,9 @@ describe(`Report Schema Controller`, () => {
 
       expectNoErrors(res);
       expect(res.data).to.be.array();
-      expect(res.data).to.have.lengthOf(reports.length + defaultReportScehmas.length);
+      expect(res.data).to.have.lengthOf(reports.length + defaultReportSchemas.length);
       const dataIds = res.data.map((x: ReportSchema) => x.id);
-      for (const defaultReport of defaultReportScehmas) {
+      for (const defaultReport of defaultReportSchemas) {
         expect(dataIds).to.include(defaultReport.id);
       }
       expect(dataIds).to.include(reports[0].id);
@@ -54,15 +54,16 @@ describe(`Report Schema Controller`, () => {
         where: { org },
       });
 
-      const body = {
+      const body: AddReportBody = {
         id: uniqueString(),
         name: uniqueString(),
         columns: [{
           keyPath: [uniqueString(), uniqueString()],
           phi: false,
           pii: false,
+          type: 'string',
         }],
-      } as ReportBody;
+      };
 
       const res = await req.post(`/${org.id}`, body);
 
@@ -102,14 +103,15 @@ describe(`Report Schema Controller`, () => {
     it(`updates a report in an org`, async () => {
       const report = await seedReport(org);
 
-      const body = {
+      const body: UpdateReportBody = {
         name: uniqueString(),
         columns: [...report.columns, {
           keyPath: [uniqueString(), uniqueString()],
           phi: false,
           pii: false,
+          type: 'string',
         }],
-      } as ReportBody;
+      };
 
       const res = await req.put(`/${org.id}/${report.id}`, body);
 

--- a/server/api/report-schema/report-schema.controller.spec.ts
+++ b/server/api/report-schema/report-schema.controller.spec.ts
@@ -1,0 +1,176 @@
+import { expect } from 'chai';
+import { expectNoErrors } from '../../util/test-utils/expect';
+import {
+  seedOrgContactRoles,
+} from '../../util/test-utils/seed';
+import { TestRequest } from '../../util/test-utils/test-request';
+import {
+  uniqueString,
+} from '../../util/test-utils/unique';
+import { Org } from '../org/org.model';
+import { User } from '../user/user.model';
+import { seedReport, seedReports } from './report-schema.model.mock';
+import { defaultReportScehmas, ReportSchema } from './report-schema.model';
+import { ReportBody } from './report-schema.controller';
+
+describe(`Report Schema Controller`, () => {
+
+  const basePath = '/api/report';
+  let req: TestRequest;
+  let org: Org;
+  let contact: User;
+
+  beforeEach(async () => {
+    ({ org, contact } = await seedOrgContactRoles());
+    req = new TestRequest(basePath);
+    req.setUser(contact);
+  });
+
+  describe(`${basePath}/:orgId : get`, () => {
+
+    it(`gets the org's report schemas`, async () => {
+      const reports = await seedReports(org, { count: 2 });
+
+      const res = await req.get(`/${org.id}`);
+
+      expectNoErrors(res);
+      expect(res.data).to.be.array();
+      expect(res.data).to.have.lengthOf(reports.length + defaultReportScehmas.length);
+      const dataIds = res.data.map((x: ReportSchema) => x.id);
+      for (const defaultReport of defaultReportScehmas) {
+        expect(dataIds).to.include(defaultReport.id);
+      }
+      expect(dataIds).to.include(reports[0].id);
+      expect(dataIds).to.include(reports[1].id);
+    });
+
+  });
+
+  describe(`${basePath}/:orgId : post`, () => {
+
+    it(`adds a report schema to the org`, async () => {
+      const reportCountBefore = await ReportSchema.count();
+      const orgReportCountBefore = await ReportSchema.count({
+        where: { org },
+      });
+
+      const body = {
+        id: uniqueString(),
+        name: uniqueString(),
+        columns: [{
+          keyPath: [uniqueString(), uniqueString()],
+          phi: false,
+          pii: false,
+        }],
+      } as ReportBody;
+
+      const res = await req.post(`/${org.id}`, body);
+
+      expectNoErrors(res);
+      expect(res.data).to.include.keys([
+        'id',
+        'name',
+        'org',
+        'columns',
+      ]);
+      const reportId = res.data.id;
+
+      const reportAfter = (await ReportSchema.findOne({
+        relations: ['org'],
+        where: {
+          id: reportId,
+          org: org.id,
+        },
+      }))!;
+      expect(reportAfter).to.exist;
+      expect(reportAfter.name).to.eql(body.name);
+      expect(reportAfter.org).to.exist;
+      expect(reportAfter.org!.id).to.eql(org.id);
+      expect(reportAfter.columns).to.eql(body.columns);
+
+      expect(await ReportSchema.count()).to.eql(reportCountBefore + 1);
+      const orgReportCountAfter = await ReportSchema.count({
+        where: { org },
+      });
+      expect(orgReportCountAfter).to.eql(orgReportCountBefore + 1);
+    });
+
+  });
+
+  describe(`${basePath}/:orgId/:reportId : put`, () => {
+
+    it(`updates a report in an org`, async () => {
+      const report = await seedReport(org);
+
+      const body = {
+        name: uniqueString(),
+        columns: [...report.columns, {
+          keyPath: [uniqueString(), uniqueString()],
+          phi: false,
+          pii: false,
+        }],
+      } as ReportBody;
+
+      const res = await req.put(`/${org.id}/${report.id}`, body);
+
+      expectNoErrors(res);
+      expect(res.data).to.include.keys([
+        'id',
+        'name',
+        'org',
+        'columns',
+      ]);
+      expect(res.data.id).to.eql(report.id);
+
+      const reportAfter = (await ReportSchema.findOne({
+        relations: ['org'],
+        where: {
+          id: report.id,
+          org: org.id,
+        },
+      }))!;
+      expect(reportAfter.name).to.eql(body.name);
+      expect(reportAfter.columns).to.eql(body.columns);
+    });
+
+  });
+
+  describe(`${basePath}/:orgId/:reportId : delete`, () => {
+
+    it(`deletes the org's report`, async () => {
+      const reports = await seedReports(org, { count: 2 });
+
+      const reportsCountBefore = await ReportSchema.count();
+
+      const reportBefore = await ReportSchema.findOne({
+        relations: ['org'],
+        where: {
+          id: reports[0].id,
+          org: org.id,
+        },
+      });
+      expect(reportBefore).to.exist;
+
+      const res = await req.delete(`/${org.id}/${reports[0].id}`);
+
+      expectNoErrors(res);
+      expect(res.data).to.include.keys([
+        'name',
+        'columns',
+      ]);
+
+      expect(await ReportSchema.count()).to.eql(reportsCountBefore - 1);
+
+      const reportAfter = await ReportSchema.findOne({
+        relations: ['org'],
+        where: {
+          id: reports[0].id,
+          org: org.id,
+        },
+      });
+      expect(reportAfter).not.to.exist;
+    });
+
+  });
+
+});

--- a/server/api/report-schema/report-schema.controller.ts
+++ b/server/api/report-schema/report-schema.controller.ts
@@ -1,0 +1,136 @@
+import { Response } from 'express';
+import { ApiRequest, OrgParam, OrgReportParams } from '../index';
+import { BadRequestError, NotFoundError } from '../../util/error-types';
+import { ReportSchema, SchemaColumn } from './report-schema.model';
+
+class ReportSchemaController {
+
+  async getOrgReports(req: ApiRequest, res: Response) {
+    if (!req.appOrg || !req.appUserRole) {
+      throw new NotFoundError('Organization was not found.');
+    }
+
+    const reports = await ReportSchema.find({
+      relations: ['org'],
+      where: {
+        org: req.appOrg.id,
+      },
+      order: {
+        id: 'ASC',
+      },
+    });
+
+    res.json(reports);
+  }
+
+  async addReport(req: ApiRequest<OrgParam, ReportBody>, res: Response) {
+    if (!req.appOrg) {
+      throw new NotFoundError('Organization was not found.');
+    }
+
+    if (!req.body.id) {
+      throw new BadRequestError('An ID must be supplied when adding a report type.');
+    }
+
+    if (!req.body.name) {
+      throw new BadRequestError('A name must be supplied when adding a report type.');
+    }
+
+    if (!req.body.columns) {
+      throw new BadRequestError('A schema must be supplied when adding a report type.');
+    }
+
+    const report = new ReportSchema();
+    report.id = req.body.id;
+    report.org = req.appOrg;
+    await setReportFromBody(report, req.body);
+
+    const newReport = await report.save();
+
+    res.status(201).json(newReport);
+  }
+
+  async getReport(req: ApiRequest<OrgReportParams>, res: Response) {
+    if (!req.appOrg) {
+      throw new NotFoundError('Organization was not found.');
+    }
+
+    const report = await ReportSchema.findOne({
+      relations: ['org'],
+      where: {
+        id: req.params.reportId,
+        org: req.appOrg.id,
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundError('Report could not be found.');
+    }
+
+    res.json(report);
+  }
+
+  async deleteReport(req: ApiRequest<OrgReportParams>, res: Response) {
+    if (!req.appOrg) {
+      throw new NotFoundError('Organization was not found.');
+    }
+
+    const report = await ReportSchema.findOne({
+      relations: ['org'],
+      where: {
+        id: req.params.reportId,
+        org: req.appOrg.id,
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundError('Report could not be found.');
+    }
+
+    const removedReport = await report.remove();
+    res.json(removedReport);
+  }
+
+  async updateReport(req: ApiRequest<OrgReportParams, ReportBody>, res: Response) {
+    if (!req.appOrg) {
+      throw new NotFoundError('Organization was not found.');
+    }
+
+    const report = await ReportSchema.findOne({
+      relations: ['org'],
+      where: {
+        id: req.params.reportId,
+        org: req.appOrg.id,
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundError('Report could not be found.');
+    }
+
+    await setReportFromBody(report, req.body);
+
+    const updatedReport = await report.save();
+
+    res.json(updatedReport);
+  }
+
+}
+
+async function setReportFromBody(report: ReportSchema, body: ReportBody) {
+  if (body.name != null) {
+    report.name = body.name;
+  }
+
+  if (body.columns != null) {
+    report.columns = body.columns;
+  }
+}
+
+export type ReportBody = {
+  id?: string
+  name?: string
+  columns?: SchemaColumn[]
+};
+
+export default new ReportSchemaController();

--- a/server/api/report-schema/report-schema.model.mock.ts
+++ b/server/api/report-schema/report-schema.model.mock.ts
@@ -1,0 +1,33 @@
+import { uniqueString } from '../../util/test-utils/unique';
+import { Org } from '../org/org.model';
+import { ReportSchema } from './report-schema.model';
+
+export function mockReport(org: Org) {
+  return ReportSchema.create({
+    id: uniqueString(),
+    name: uniqueString(),
+    columns: [{
+      keyPath: [uniqueString(), uniqueString()],
+      phi: false,
+      pii: false,
+    }],
+    org,
+  });
+}
+
+export function seedReport(org: Org) {
+  return mockReport(org).save();
+}
+
+export function seedReports(org: Org, options: {
+  count: number
+}) {
+  const { count } = options;
+  const reports = [] as ReportSchema[];
+
+  for (let i = 0; i < count; i++) {
+    reports.push(mockReport(org));
+  }
+
+  return ReportSchema.save(reports);
+}

--- a/server/api/report-schema/report-schema.model.ts
+++ b/server/api/report-schema/report-schema.model.ts
@@ -1,0 +1,171 @@
+import {
+  Entity,
+  Column,
+  BaseEntity,
+  PrimaryColumn, ManyToOne, JoinColumn,
+} from 'typeorm';
+import { Org } from '../org/org.model';
+
+@Entity()
+export class ReportSchema extends BaseEntity {
+
+  @PrimaryColumn()
+  id!: string;
+
+  @ManyToOne(() => Org, {
+    primary: true,
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({
+    name: 'org_id',
+  })
+  org?: Org;
+
+  @Column({
+    length: 256,
+  })
+  name!: string;
+
+  @Column('json', {
+    nullable: false,
+    default: '[]',
+  })
+  columns: SchemaColumn[] = [];
+}
+
+export interface SchemaColumn {
+  keyPath: string[]
+  type: string
+  otherField?: boolean
+  pii: boolean
+  phi: boolean
+}
+
+export const defaultReportScehmas: Partial<ReportSchema>[] = [{
+  id: 'es6ddssymptomobs',
+  name: 'Symptom Observation Report',
+  columns: [{
+    keyPath: ['Details', 'Affiliation'],
+    type: 'string',
+    pii: false,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'City'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'ConditionState'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'Conditions'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'Confirmed'],
+    type: 'long',
+    pii: false,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'Exposures'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'Installation'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'Location'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'Lodging'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'Medications'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'PhoneNumber'],
+    type: 'string',
+    pii: true,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'ROM'],
+    type: 'long',
+    pii: false,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'ROMContact'],
+    type: 'string',
+    pii: true,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'ROMStartDate'],
+    type: 'string',
+    pii: false,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'ROMSupport'],
+    type: 'long',
+    pii: false,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'RoomNumber'],
+    type: 'string',
+    pii: true,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'Ship'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'SpO2Percent'],
+    type: 'float',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'Symptoms'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'TalkToSomeone'],
+    type: 'long',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'TemperatureFahrenheit'],
+    type: 'float',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'TentOrBillet'],
+    type: 'string',
+    pii: true,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'Unit'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }],
+}];

--- a/server/api/report-schema/report-schema.model.ts
+++ b/server/api/report-schema/report-schema.model.ts
@@ -42,7 +42,7 @@ export interface SchemaColumn {
   phi: boolean
 }
 
-export const defaultReportScehmas: Partial<ReportSchema>[] = [{
+export const defaultReportSchemas: Partial<ReportSchema>[] = [{
   id: 'es6ddssymptomobs',
   name: 'Symptom Observation Report',
   columns: [{

--- a/server/api/roster/roster.controller.ts
+++ b/server/api/roster/roster.controller.ts
@@ -272,7 +272,7 @@ class RosterController {
       .leftJoinAndSelect('roster.unit', 'unit')
       .leftJoinAndSelect('unit.org', 'org')
       .where('roster.edipi = :edipi', { edipi: req.params.edipi })
-      .andWhere('roster.timestamp <= to_timestamp(:timestamp)', { timestamp })
+      .andWhere(`roster.timestamp <= to_timestamp(:timestamp) AT TIME ZONE '+0'`, { timestamp })
       .select()
       .distinctOn(['roster.unit_id'])
       .orderBy('roster.unit_id')
@@ -378,6 +378,7 @@ class RosterController {
       },
     });
 
+    let updatedRosterEntry: Roster | null = null;
     await getConnection().transaction(async manager => {
       if (!entry) {
         throw new NotFoundError('User could not be found.');
@@ -397,9 +398,9 @@ class RosterController {
 
       const columns = await Roster.getAllowedColumns(req.appOrg!, req.appUserRole!.role);
       await setRosterParamsFromBody(req.appOrg!, entry, req.body, columns);
-      const updatedRosterEntry = await manager.save(entry);
-      res.json(updatedRosterEntry);
+      updatedRosterEntry = await manager.save(entry);
     });
+    res.json(updatedRosterEntry);
   }
 
 }

--- a/server/api/unit/unit.model.ts
+++ b/server/api/unit/unit.model.ts
@@ -38,4 +38,5 @@ export interface MusterConfiguration {
   startTime: string,
   timezone: string,
   durationMinutes: number,
+  reportId: string,
 }

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -57,10 +57,6 @@ export async function requireUserAuth(req: AuthRequest, res: Response, next: Nex
       where: {
         edipi: id,
       },
-      cache: {
-        id: `user_auth_${id}`,
-        milliseconds: 30000,
-      },
     });
   }
 

--- a/server/migration/1611337083465-RosterHistory.ts
+++ b/server/migration/1611337083465-RosterHistory.ts
@@ -52,7 +52,7 @@ export class RosterHistory1611337083465 implements MigrationInterface {
       for (const row of unitHistory) {
         await queryRunner.query(`
           INSERT INTO roster_history (unit_id, unit_org, edipi, first_name, last_name, custom_columns, change_type, timestamp)
-          VALUES ($1, $2, $3, $4, $5, $6, $7, to_timestamp($8))
+          VALUES ($1, $2, $3, $4, $5, $6, $7, to_timestamp($8) AT TIME ZONE '+0')
         `, [row.unit_id, row.unit_org, row.edipi, row.first_name, row.last_name, row.custom_columns, row.change_type, row.timestamp.getTime() / 1000]);
       }
     }

--- a/server/migration/1614813673069-AddReportSchemas.ts
+++ b/server/migration/1614813673069-AddReportSchemas.ts
@@ -9,7 +9,7 @@ export class AddReportSchemas1614813673069 implements MigrationInterface {
     for (const org of orgs) {
       await queryRunner.query(
         `INSERT INTO "report_schema"("id", "name", "columns", "org_id") VALUES ($1, $2, $3, $4)`,
-        [defaultReportScehma.id, defaultReportScehma.name, JSON.stringify(defaultReportScehma.columns), org.id],
+        [defaultReportSchema.id, defaultReportSchema.name, JSON.stringify(defaultReportSchema.columns), org.id],
       );
       const orgUnits = await queryRunner.query(`SELECT id, muster_configuration FROM unit WHERE org_id=${org.id}`) as { id: number, muster_configuration: MusterConfiguration[] }[];
       for (const unit of orgUnits) {
@@ -17,7 +17,7 @@ export class AddReportSchemas1614813673069 implements MigrationInterface {
           continue;
         }
         for (const musterConfiguration of unit.muster_configuration) {
-          musterConfiguration.reportId = defaultReportScehma.id;
+          musterConfiguration.reportId = defaultReportSchema.id;
         }
         await queryRunner.query(
           `UPDATE "unit" SET muster_configuration=$1 WHERE id=${unit.id}`,
@@ -46,7 +46,7 @@ export interface MusterConfiguration {
 }
 
 
-const defaultReportScehma = {
+const defaultReportSchema = {
   id: 'es6ddssymptomobs',
   name: 'Symptom Observation Report',
   columns: [{

--- a/server/migration/1614813673069-AddReportSchemas.ts
+++ b/server/migration/1614813673069-AddReportSchemas.ts
@@ -1,0 +1,175 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddReportSchemas1614813673069 implements MigrationInterface {
+  name = 'AddReportSchemas1614813673069';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TABLE "report_schema" ("id" character varying NOT NULL, "name" character varying(256) NOT NULL, "columns" json NOT NULL DEFAULT '[]', "org_id" integer NOT NULL, CONSTRAINT "PK_c19c025244ceedaff94736f021f" PRIMARY KEY ("id", "org_id"))`);
+    const orgs = await queryRunner.query(`SELECT id FROM "org"`);
+    for (const org of orgs) {
+      await queryRunner.query(
+        `INSERT INTO "report_schema"("id", "name", "columns", "org_id") VALUES ($1, $2, $3, $4)`,
+        [defaultReportScehma.id, defaultReportScehma.name, JSON.stringify(defaultReportScehma.columns), org.id],
+      );
+      const orgUnits = await queryRunner.query(`SELECT id, muster_configuration FROM unit WHERE org_id=${org.id}`) as { id: number, muster_configuration: MusterConfiguration[] }[];
+      for (const unit of orgUnits) {
+        if (unit.muster_configuration == null) {
+          continue;
+        }
+        for (const musterConfiguration of unit.muster_configuration) {
+          musterConfiguration.reportId = defaultReportScehma.id;
+        }
+        await queryRunner.query(
+          `UPDATE "unit" SET muster_configuration=$1 WHERE id=${unit.id}`,
+          [JSON.stringify(unit.muster_configuration)],
+        );
+      }
+    }
+    await queryRunner.query(`ALTER TABLE "user_notification_setting" ALTER COLUMN "last_notified_date" SET DEFAULT null`);
+    await queryRunner.query(`ALTER TABLE "report_schema" ADD CONSTRAINT "FK_d1ffa8699456464f8d833838cba" FOREIGN KEY ("org_id") REFERENCES "org"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "report_schema" DROP CONSTRAINT "FK_d1ffa8699456464f8d833838cba"`);
+    await queryRunner.query(`ALTER TABLE "user_notification_setting" ALTER COLUMN "last_notified_date" DROP DEFAULT`);
+    await queryRunner.query(`DROP TABLE "report_schema"`);
+  }
+
+}
+
+export interface MusterConfiguration {
+  days: number,
+  startTime: string,
+  timezone: string,
+  durationMinutes: number,
+  reportId?: string,
+}
+
+
+const defaultReportScehma = {
+  id: 'es6ddssymptomobs',
+  name: 'Symptom Observation Report',
+  columns: [{
+    keyPath: ['Details', 'Affiliation'],
+    type: 'string',
+    pii: false,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'City'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'ConditionState'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'Conditions'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'Confirmed'],
+    type: 'long',
+    pii: false,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'Exposures'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'Installation'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'Location'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'Lodging'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'Medications'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'PhoneNumber'],
+    type: 'string',
+    pii: true,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'ROM'],
+    type: 'long',
+    pii: false,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'ROMContact'],
+    type: 'string',
+    pii: true,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'ROMStartDate'],
+    type: 'string',
+    pii: false,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'ROMSupport'],
+    type: 'long',
+    pii: false,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'RoomNumber'],
+    type: 'string',
+    pii: true,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'Ship'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }, {
+    keyPath: ['Details', 'SpO2Percent'],
+    type: 'float',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'Symptoms'],
+    type: 'string',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'TalkToSomeone'],
+    type: 'long',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'TemperatureFahrenheit'],
+    type: 'float',
+    pii: true,
+    phi: true,
+  }, {
+    keyPath: ['Details', 'TentOrBillet'],
+    type: 'string',
+    pii: true,
+    phi: false,
+  }, {
+    keyPath: ['Details', 'Unit'],
+    type: 'string',
+    pii: true,
+    phi: false,
+    otherField: true,
+  }],
+};

--- a/server/mocha-setup.ts
+++ b/server/mocha-setup.ts
@@ -16,6 +16,7 @@ import { Notification } from './api/notification/notification.model';
 import { WorkspaceTemplate } from './api/workspace/workspace-template.model';
 import { Workspace } from './api/workspace/workspace.model';
 import server from './app';
+import { ReportSchema } from './api/report-schema/report-schema.model';
 
 chai.use(chaiAsPromised);
 chai.use(chaiSubset);
@@ -37,6 +38,7 @@ beforeEach(async () => {
     await CustomRosterColumn.delete({});
     await Roster.delete({});
     await RosterHistory.delete({});
+    await ReportSchema.delete({});
     await Unit.delete({});
     await UserNotificationSetting.delete({});
     await Notification.delete({});

--- a/server/ormconfig.ts
+++ b/server/ormconfig.ts
@@ -8,6 +8,7 @@ import { Roster } from './api/roster/roster.model';
 import { User } from './api/user/user.model';
 import { Unit } from './api/unit/unit.model';
 import { Workspace } from './api/workspace/workspace.model';
+import { ReportSchema } from './api/report-schema/report-schema.model';
 import { WorkspaceTemplate } from './api/workspace/workspace-template.model';
 import { CustomRosterColumn } from './api/roster/custom-roster-column.model';
 import { Notification } from './api/notification/notification.model';
@@ -32,6 +33,7 @@ export const ormConfig: PostgresConnectionOptions = {
     AccessRequest,
     Unit,
     Workspace,
+    ReportSchema,
     WorkspaceTemplate,
     CustomRosterColumn,
     Notification,

--- a/server/sqldb/seed-dev.ts
+++ b/server/sqldb/seed-dev.ts
@@ -11,7 +11,7 @@ import { Unit } from '../api/unit/unit.model';
 import { env } from '../util/env';
 import { Log } from '../util/log';
 import { RosterHistory } from '../api/roster/roster-history.model';
-import { defaultReportScehmas, ReportSchema } from '../api/report-schema/report-schema.model';
+import { defaultReportSchemas, ReportSchema } from '../api/report-schema/report-schema.model';
 
 require('dotenv').config();
 
@@ -66,7 +66,7 @@ async function generateOrg(manager: EntityManager, orgNum: number, admin: User, 
   });
   org = await manager.save(org);
 
-  const reportSchemas = manager.create(ReportSchema, defaultReportScehmas);
+  const reportSchemas = manager.create(ReportSchema, defaultReportSchemas);
   for (const report of reportSchemas) {
     report.org = org;
   }

--- a/server/sqldb/seed-dev.ts
+++ b/server/sqldb/seed-dev.ts
@@ -10,6 +10,8 @@ import { CustomRosterColumn } from '../api/roster/custom-roster-column.model';
 import { Unit } from '../api/unit/unit.model';
 import { env } from '../util/env';
 import { Log } from '../util/log';
+import { RosterHistory } from '../api/roster/roster-history.model';
+import { defaultReportScehmas, ReportSchema } from '../api/report-schema/report-schema.model';
 
 require('dotenv').config();
 
@@ -39,6 +41,13 @@ export default (async function() {
     // Create Org 1 & 2 and their Users
     await generateOrg(manager, 1, groupAdmin, 5, 20);
     await generateOrg(manager, 2, groupAdmin, 5, 20);
+
+    // Set the start date on each roster entry to some time in the past to help with repeatable testing
+    await manager
+      .createQueryBuilder()
+      .update(RosterHistory)
+      .set({ timestamp: '2020-01-01 00:00:00' })
+      .execute();
   });
 
   await connection.close();
@@ -56,6 +65,12 @@ async function generateOrg(manager: EntityManager, orgNum: number, admin: User, 
     defaultMusterConfiguration: [],
   });
   org = await manager.save(org);
+
+  const reportSchemas = manager.create(ReportSchema, defaultReportScehmas);
+  for (const report of reportSchemas) {
+    report.org = org;
+  }
+  await manager.save(reportSchemas);
 
   let customColumn = manager.create(CustomRosterColumn, {
     org,

--- a/server/util/muster-utils.ts
+++ b/server/util/muster-utils.ts
@@ -233,7 +233,7 @@ export function getEarliestMusterWindowTime(muster: MusterConfiguration, referen
 
 export function buildMusterWindow(unit: Unit, startTimestamp: number, endTimestamp: number, muster: MusterConfiguration): MusterWindow {
   return {
-    id: `${unit.org!.id}-${unit.id}-${moment.unix(startTimestamp).utc().format('Y-M-D-HH-mm')}`,
+    id: `${unit.org!.id}-${unit.id}-${moment.unix(startTimestamp).utc().format('Y-M-D-HH-mm')}-${muster.reportId}`,
     orgId: unit.org!.id,
     unitId: unit.id,
     unitName: unit.name,
@@ -243,6 +243,7 @@ export function buildMusterWindow(unit: Unit, startTimestamp: number, endTimesta
     startTime: muster.startTime,
     timezone: muster.timezone,
     durationMinutes: muster.durationMinutes,
+    reportId: muster.reportId,
   };
 }
 
@@ -553,4 +554,5 @@ export interface MusterWindow {
   startTime: string,
   timezone: string,
   durationMinutes: number,
+  reportId: string,
 }

--- a/server/util/test-utils/expect.ts
+++ b/server/util/test-utils/expect.ts
@@ -5,3 +5,10 @@ import util from 'util';
 export const expectNoErrors = (res: AxiosResponse) => {
   expect(res.data, util.inspect(res.data, { depth: 4 })).not.to.have.property('errors');
 };
+
+export const expectError = (res: AxiosResponse, error: string) => {
+  expect(res.data, util.inspect(res.data, { depth: 4 })).to.have.property('errors');
+  expect(res.data.errors).to.have.lengthOf(1);
+  expect(res.data.errors[0]).to.have.property('message');
+  expect(res.data.errors[0].message).to.have.string(error);
+};

--- a/server/util/util.ts
+++ b/server/util/util.ts
@@ -111,7 +111,7 @@ export const timestampColumnTransformer: ValueTransformer = {
     return value ? moment.utc(value).toDate() : value;
   },
   to: value => {
-    return value ? moment(value).toISOString() : value;
+    return value ? moment.utc(value).format('YYYY-MM-DD HH:mm:ss.SSS') : value;
   },
 };
 

--- a/src/actions/report-schema.actions.ts
+++ b/src/actions/report-schema.actions.ts
@@ -1,0 +1,39 @@
+import { Dispatch } from 'redux';
+import { ReportSchemaClient } from '../client';
+import { ApiReportSchema } from '../models/api-response';
+
+export namespace ReportSchema {
+
+  export namespace Actions {
+
+    export class Fetch {
+      static type = 'FETCH_REPORT_SCHEMAS';
+      type = Fetch.type;
+    }
+    export class FetchSuccess {
+      static type = `${Fetch.type}_SUCCESS`;
+      type = FetchSuccess.type;
+      constructor(public payload: {
+        reports: ApiReportSchema[]
+      }) {}
+    }
+    export class FetchFailure {
+      static type = `${Fetch.type}_FAILURE`;
+      type = FetchFailure.type;
+      constructor(public payload: {
+        error: any
+      }) { }
+    }
+  }
+
+  export const fetch = (orgId: number) => async (dispatch: Dispatch) => {
+    dispatch(new Actions.Fetch());
+    try {
+      const reports = await ReportSchemaClient.fetchAll(orgId);
+      dispatch(new Actions.FetchSuccess({ reports }));
+    } catch (error) {
+      dispatch(new Actions.FetchFailure({ error }));
+    }
+  };
+}
+

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -2,7 +2,7 @@ import axios, { AxiosError, AxiosResponse } from 'axios';
 import axiosRetry from 'axios-retry';
 import { UserRegisterData } from '../actions/user.actions';
 import {
-  ApiAccessRequest, ApiNotification, ApiRole, ApiRosterColumnInfo, ApiUnit, ApiUser, ApiWorkspace,
+  ApiAccessRequest, ApiNotification, ApiReportSchema, ApiRole, ApiRosterColumnInfo, ApiUnit, ApiUser, ApiWorkspace,
 } from '../models/api-response';
 
 const client = axios.create({
@@ -56,6 +56,12 @@ export namespace RoleClient {
 export namespace UnitClient {
   export const fetchAll = (orgId: number): Promise<ApiUnit[]> => {
     return client.get(`unit/${orgId}`);
+  };
+}
+
+export namespace ReportSchemaClient {
+  export const fetchAll = (orgId: number): Promise<ApiReportSchema[]> => {
+    return client.get(`report/${orgId}`);
   };
 }
 

--- a/src/components/pages/units-page/default-muster-dialog.styles.ts
+++ b/src/components/pages/units-page/default-muster-dialog.styles.ts
@@ -110,11 +110,14 @@ export default makeStyles((theme: Theme) => createStyles({
     color: theme.palette.text.primary,
     backgroundColor: 'white',
   },
+  reportCell: {
+    width: '20%',
+  },
   durationCell: {
-    width: '17%',
+    width: '12%',
   },
   timeZoneCell: {
-    width: '30%',
+    width: '20%',
     '& .MuiAutocomplete-inputRoot': {
       padding: '8px 12px',
       '& > input': {

--- a/src/components/pages/units-page/edit-unit-dialog.styles.ts
+++ b/src/components/pages/units-page/edit-unit-dialog.styles.ts
@@ -100,11 +100,14 @@ export default makeStyles((theme: Theme) => createStyles({
   dayButtonDisabled: {
     opacity: 0.7,
   },
+  reportCell: {
+    width: '20%',
+  },
   durationCell: {
-    width: '17%',
+    width: '12%',
   },
   timeZoneCell: {
-    width: '30%',
+    width: '20%',
     '& .MuiAutocomplete-inputRoot': {
       padding: '8px 12px',
       '& > input': {

--- a/src/components/pages/units-page/muster-config-readable.tsx
+++ b/src/components/pages/units-page/muster-config-readable.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { Typography, TypographyProps } from '@material-ui/core';
-import { MusterConfiguration } from '../../../models/api-response';
+import { ApiReportSchema, MusterConfiguration } from '../../../models/api-response';
 import { musterConfigurationsToStrings } from '../../../utility/muster-utils';
 
 export type MusterConfigProps = {
   className?: string,
+  reports: ApiReportSchema[],
   musterConfiguration: MusterConfiguration[] | undefined,
   typographyProps?: TypographyProps,
 };
 
-export default function MusterConfigReadable({ className, musterConfiguration, typographyProps }: MusterConfigProps) {
+export default function MusterConfigReadable({ className, reports, musterConfiguration, typographyProps }: MusterConfigProps) {
   return (
     <div className={className}>
-      {musterConfigurationsToStrings(musterConfiguration)
+      {musterConfigurationsToStrings(musterConfiguration, reports)
         .map(muster => (
           <Typography key={muster} variant="body1" {...typographyProps}>
             {muster}

--- a/src/components/pages/units-page/units-page.tsx
+++ b/src/components/pages/units-page/units-page.tsx
@@ -40,13 +40,15 @@ import { EditUnitDialog, EditUnitDialogProps } from './edit-unit-dialog';
 import { UnitSelector } from '../../../selectors/unit.selector';
 import { Unit } from '../../../actions/unit.actions';
 import PageHeader from '../../page-header/page-header';
-import { musterConfigurationToString } from '../../../utility/muster-utils';
+import { musterConfigurationsToStrings } from '../../../utility/muster-utils';
 import { Modal } from '../../../actions/modal.actions';
 import { formatMessage } from '../../../utility/errors';
 import { DefaultMusterDialog, DefaultMusterDialogProps } from './default-muster-dialog';
 import { User } from '../../../actions/user.actions';
 import { UserSelector } from '../../../selectors/user.selector';
 import MusterConfigReadable from './muster-config-readable';
+import { ReportSchemaSelector } from '../../../selectors/report-schema.selector';
+import { ReportSchema } from '../../../actions/report-schema.actions';
 
 interface UnitMenuState {
   anchor: HTMLElement | null,
@@ -55,10 +57,11 @@ interface UnitMenuState {
 
 export const UnitsPage = () => {
   const { id: orgId, defaultMusterConfiguration = [] } = useSelector(UserSelector.org) ?? {};
-  const initialEditUnitState = { open: false, defaultMusterConfiguration };
   const classes = useStyles();
   const dispatch = useDispatch();
   const units = useSelector(UnitSelector.all);
+  const reports = useSelector(ReportSchemaSelector.all);
+  const initialEditUnitState = { open: false, defaultMusterConfiguration };
   const [unitToDelete, setUnitToDelete] = useState<null | ApiUnit>(null);
   const [editUnitDialogProps, setEditUnitDialogProps] = useState<EditUnitDialogProps>(initialEditUnitState);
   const [defaultMusterDialogProps, setDefaultMusterDialogProps] = useState<DefaultMusterDialogProps>({ open: false });
@@ -68,6 +71,7 @@ export const UnitsPage = () => {
   const initializeTable = React.useCallback(async () => {
     if (orgId) {
       await dispatch(Unit.fetch(orgId));
+      await dispatch(ReportSchema.fetch(orgId));
     }
   }, [orgId, dispatch]);
 
@@ -169,7 +173,11 @@ export const UnitsPage = () => {
         <Card>
           <CardHeader title="Default Muster Requirements" />
           <CardContent>
-            <MusterConfigReadable className={classes.musterConfiguration} musterConfiguration={defaultMusterConfiguration} />
+            <MusterConfigReadable
+              className={classes.musterConfiguration}
+              reports={reports}
+              musterConfiguration={defaultMusterConfiguration}
+            />
             <CardActions>
               <Button
                 size="large"
@@ -214,9 +222,9 @@ export const UnitsPage = () => {
                       <TableCell>{unit.name}</TableCell>
                       {!!unit.musterConfiguration?.length && (
                         <TableCell className={classes.musterConfiguration}>
-                          {unit.musterConfiguration.map((muster, index) => (
+                          {musterConfigurationsToStrings(unit.musterConfiguration, reports).map((muster, index) => (
                             <div key={JSON.stringify({ muster, index })}>
-                              {musterConfigurationToString(muster)}
+                              {muster}
                             </div>
                           ))}
                         </TableCell>

--- a/src/components/pages/user-registration-page/user-registration-page.tsx
+++ b/src/components/pages/user-registration-page/user-registration-page.tsx
@@ -39,7 +39,6 @@ export const UserRegistrationPage = () => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const user = useSelector<AppState, UserState>(state => state.user);
-  const onboardingUrl = `${process.env.REACT_APP_ONBOARDING_LINK}`;
   const [registerUserLoading, setRegisterUserLoading] = useState(false);
   const [inputData, setInputData] = useState<UserRegisterDataWithValidation>({
     firstName: { hasBlurred: false, hasChanged: false, helperText: '', value: '' },

--- a/src/models/api-response.ts
+++ b/src/models/api-response.ts
@@ -186,6 +186,12 @@ export interface MusterConfiguration {
   startTime: string,
   timezone: string,
   durationMinutes: number,
+  reportId: string,
+}
+
+export interface ApiReportSchema {
+  id: string,
+  name: string,
 }
 
 export interface ApiUnit {

--- a/src/reducers/report-schema.reducer.ts
+++ b/src/reducers/report-schema.reducer.ts
@@ -1,0 +1,46 @@
+import { User } from '../actions/user.actions';
+import { ApiReportSchema } from '../models/api-response';
+import { ReportSchema } from '../actions/report-schema.actions';
+
+export interface ReportSchemaState {
+  reports: ApiReportSchema[],
+  isLoading: boolean
+  lastUpdated: number
+}
+
+export const reportSchemaInitialState: ReportSchemaState = {
+  reports: [],
+  isLoading: false,
+  lastUpdated: 0,
+};
+
+export function reportSchemaReducer(state = reportSchemaInitialState, action: any) {
+  switch (action.type) {
+    case User.Actions.ChangeOrg.type:
+      return reportSchemaInitialState;
+    case ReportSchema.Actions.Fetch.type: {
+      return {
+        ...state,
+        isLoading: true,
+      };
+    }
+    case ReportSchema.Actions.FetchSuccess.type: {
+      const payload = (action as ReportSchema.Actions.FetchSuccess).payload;
+      return {
+        ...state,
+        reports: payload.reports,
+        isLoading: false,
+        lastUpdated: Date.now(),
+      };
+    }
+    case ReportSchema.Actions.FetchFailure.type: {
+      return {
+        ...state,
+        reports: [],
+        isLoading: false,
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/src/selectors/report-schema.selector.ts
+++ b/src/selectors/report-schema.selector.ts
@@ -1,0 +1,6 @@
+import { ApiReportSchema } from '../models/api-response';
+import { AppState } from '../store';
+
+export namespace ReportSchemaSelector {
+  export const all = (state: AppState): ApiReportSchema[] => state.reportSchema.reports;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,6 +29,10 @@ import {
   rosterReducer,
 } from './reducers/roster.reducer';
 import {
+  reportSchemaInitialState,
+  reportSchemaReducer,
+} from './reducers/report-schema.reducer';
+import {
   localStorageInitialState,
   localStorageReducer,
 } from './reducers/local-storage.reducer';
@@ -55,6 +59,7 @@ export const initialState = {
   modal: modalInitialState,
   role: roleInitialState,
   unit: unitInitialState,
+  reportSchema: reportSchemaInitialState,
   roster: rosterInitialState,
   user: userInitialState,
   workspace: workspaceInitialState,
@@ -120,6 +125,7 @@ export const configureStore = () => {
         role: roleReducer,
         unit: unitReducer,
         roster: rosterReducer,
+        reportSchema: reportSchemaReducer,
         user: userReducer,
         workspace: workspaceReducer,
         localStorage: localStorageReducer,


### PR DESCRIPTION
This PR adds an additional table to store report schemas that can be used by the processor in order to support group-specific report types.  It also allows the user to associate muster windows with a specific type or report.

![image](https://user-images.githubusercontent.com/2428907/110036823-9a31cf80-7d0b-11eb-9fbe-55cf5a42332e.png)
![image](https://user-images.githubusercontent.com/2428907/110036874-aae24580-7d0b-11eb-947e-0e3f6c00ee5e.png)
