### PR TITLE
Fix/disallow spaces in custom column names.

### DIFF
--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -78,7 +78,7 @@ export type SettingParam = {
   settingId: string
 };
 
-export type ColumnNameParam = {
+export type ColumnParam = {
   columnName: string
 };
 
@@ -93,7 +93,7 @@ export type OrgRosterParams = OrgParam & RosterParam;
 export type OrgWorkspaceParams = OrgParam & WorkspaceParam;
 export type OrgUnitParams = OrgParam & UnitParam;
 export type OrgSettingParams = OrgParam & SettingParam;
-export type OrgColumnNameParams = OrgParam & ColumnNameParam;
+export type OrgColumnParams = OrgParam & ColumnParam;
 
 export type PagedQuery = {
   limit: string

--- a/server/api/roster/custom-roster-column.model.ts
+++ b/server/api/roster/custom-roster-column.model.ts
@@ -1,7 +1,16 @@
 import {
-  Entity, Column, BaseEntity, JoinColumn, ManyToOne, PrimaryColumn,
+  Entity,
+  Column,
+  BaseEntity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  BeforeInsert,
+  BeforeUpdate,
 } from 'typeorm';
+import _ from 'lodash';
 import { Org } from '../org/org.model';
+import { baseRosterColumns } from './roster-entity';
 import { RosterColumnType } from './roster.types';
 
 @Entity()
@@ -51,6 +60,59 @@ export class CustomRosterColumn extends BaseEntity {
     default: '{}',
   })
   config!: CustomColumnConfig;
+
+  @BeforeInsert()
+  async beforeInsert() {
+    this.name = CustomRosterColumn.displayToName(this.display);
+
+    const existingColumn = await CustomRosterColumn.findOne({
+      where: {
+        name: this.name,
+        org: this.org!.id,
+      },
+    });
+
+    if (existingColumn || this.name === 'unit' || baseRosterColumns.some(x => x.name === this.name)) {
+      throw new Error(`A roster column with that name already exists.`);
+    }
+  }
+
+  @BeforeUpdate()
+  beforeUpdate() {
+    const updatedName = CustomRosterColumn.displayToName(this.display);
+    if (updatedName !== this.name) {
+      throw new Error(`Roster column name cannot be changed!`);
+    }
+  }
+
+  setFromData(data: CustomColumnData) {
+    if (data.displayName) {
+      this.display = data.displayName;
+    }
+    if (data.type) {
+      this.type = data.type;
+    }
+    if (data.pii != null) {
+      this.pii = data.pii;
+    }
+    if (data.phi != null) {
+      this.phi = data.phi;
+    }
+    if (data.required != null) {
+      this.required = data.required;
+    }
+    if (data.config != null) {
+      this.config = data.config;
+    }
+  }
+
+  static displayToName(display: string) {
+    return _.camelCase(display);
+  }
 }
+
+export type CustomColumnData = Partial<Pick<CustomRosterColumn, 'type' | 'pii' | 'phi' | 'required' | 'config'>> & {
+  displayName?: string
+};
 
 export interface CustomColumnConfig {}

--- a/server/migration/1618422617092-FixCustomColumnSpaces.ts
+++ b/server/migration/1618422617092-FixCustomColumnSpaces.ts
@@ -24,8 +24,15 @@ export class FixCustomColumnSpaces1618422617092 implements MigrationInterface {
     } = {};
     for (const customColumn of customRosterColumns) {
       const oldName = customColumn.name;
-      const newName = _.camelCase(customColumn.display);
-      await queryRunner.query(`UPDATE "custom_roster_column" SET "name" = '${newName}' WHERE "name" = '${oldName}'`);
+
+      // Rename 'Covid Test' columns to 'Covid Tested', as requested.
+      let display = customColumn.display;
+      if (display.toLowerCase() === 'covid test') {
+        display = 'Covid Tested';
+      }
+
+      const newName = _.camelCase(display);
+      await queryRunner.query(`UPDATE "custom_roster_column" SET "name" = '${newName}', "display" = '${display}' WHERE "name" = '${oldName}'`);
 
       const orgId = customColumn.org_id;
       if (newNamesLookup[orgId] == null) {

--- a/server/migration/1618422617092-FixCustomColumnSpaces.ts
+++ b/server/migration/1618422617092-FixCustomColumnSpaces.ts
@@ -1,0 +1,83 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+} from 'typeorm';
+import _ from 'lodash';
+
+export class FixCustomColumnSpaces1618422617092 implements MigrationInterface {
+  name = 'FixCustomColumnSpaces1618422617092';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Get a mapping of unit ids to org ids for looking up new names from roster data.
+    const units = await queryRunner.query(`SELECT "id", "org_id" from "unit"`);
+    const unitIdToOrgId: { [unitId: string]: string } = {};
+    for (const unit of units) {
+      unitIdToOrgId[unit.id] = unit.org_id;
+    }
+
+    // Convert custom roster column "name" values to the camelcase "display".
+    const customRosterColumns = await queryRunner.query(`SELECT "name", "display", "org_id" FROM "custom_roster_column"`);
+    const newNamesLookup: {
+      [orgId: string]: {
+        [oldName: string]: string
+      }
+    } = {};
+    for (const customColumn of customRosterColumns) {
+      const oldName = customColumn.name;
+      const newName = _.camelCase(customColumn.display);
+      await queryRunner.query(`UPDATE "custom_roster_column" SET "name" = '${newName}' WHERE "name" = '${oldName}'`);
+
+      const orgId = customColumn.org_id;
+      if (newNamesLookup[orgId] == null) {
+        newNamesLookup[orgId] = {};
+      }
+      newNamesLookup[orgId][oldName] = newName;
+    }
+
+    // Save out the roster history so that we can restore it, since it will get modified
+    // via trigger as the roster is updated.
+    const rosterHistoryEntriesSaved = await queryRunner.query(`SELECT "id", "edipi", "first_name", "last_name", "custom_columns", "timestamp", "change_type", "unit_id" FROM "roster_history"`);
+
+    // Update roster data with new custom column names.
+    const rosterEntries = await queryRunner.query(`SELECT "id", "custom_columns", "unit_id" FROM "roster"`);
+    for (const entry of rosterEntries) {
+      const orgId = unitIdToOrgId[entry.unit_id];
+      if (newNamesLookup[orgId] == null) {
+        continue;
+      }
+
+      for (const oldName of Object.keys(entry.custom_columns)) {
+        const newName = newNamesLookup[orgId][oldName];
+        if (newName !== oldName) {
+          entry.custom_columns[newName] = entry.custom_columns[oldName];
+          delete entry.custom_columns[oldName];
+        }
+      }
+
+      await queryRunner.query(`UPDATE "roster" SET "custom_columns" = '${JSON.stringify(entry.custom_columns)}' WHERE "id" = ${entry.id}`);
+    }
+
+    // Restore roster history with new custom column names.
+    await queryRunner.query(`DELETE FROM "roster_history"`);
+    for (const entry of rosterHistoryEntriesSaved) {
+      const orgId = unitIdToOrgId[entry.unit_id];
+      if (newNamesLookup[orgId] == null) {
+        continue;
+      }
+
+      for (const oldName of Object.keys(entry.custom_columns)) {
+        const newName = newNamesLookup[orgId][oldName];
+        if (newName !== oldName) {
+          entry.custom_columns[newName] = entry.custom_columns[oldName];
+          delete entry.custom_columns[oldName];
+        }
+      }
+
+      await queryRunner.query(`INSERT INTO "roster_history" ("id", "edipi", "first_name", "last_name", "custom_columns", "timestamp", "change_type", "unit_id") VALUES (${entry.id}, '${entry.edipi}', '${entry.first_name}', '${entry.last_name}', '${JSON.stringify(entry.custom_columns)}', '${entry.timestamp.toISOString()}', '${entry.change_type}', ${entry.unit_id})`);
+    }
+  }
+
+  // eslint-disable-next-line
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+
+}

--- a/server/sqldb/seed-dev.ts
+++ b/server/sqldb/seed-dev.ts
@@ -74,7 +74,6 @@ async function generateOrg(manager: EntityManager, orgNum: number, admin: User, 
 
   let customColumn = manager.create(CustomRosterColumn, {
     org,
-    name: 'myCustomColumn',
     display: `My Custom Column : Group ${orgNum}`,
     type: RosterColumnType.String,
     phi: false,

--- a/src/components/pages/muster-page/muster-page.tsx
+++ b/src/components/pages/muster-page/muster-page.tsx
@@ -141,7 +141,7 @@ export const MusterPage = () => {
   }, [orgId, dispatch]);
 
   const showErrorDialog = useCallback((title: string, error: Error) => {
-    dispatch(Modal.alert(`Error: ${title}`, formatMessage(error)));
+    dispatch(Modal.alert(`Error: ${title}`, formatMessage(error))).then();
   }, [dispatch]);
 
   const reloadTable = useCallback(async () => {
@@ -310,14 +310,14 @@ export const MusterPage = () => {
       const filename = `${_.kebabCase(orgName)}_${unitId}_muster-noncompliance_${startDate}_to_${endDate}`;
       downloadFile(response.data, filename, 'csv');
     } catch (error) {
-      dispatch(Modal.alert('Export to CSV', formatMessage(error, 'Unable to export')));
+      dispatch(Modal.alert('Export to CSV', formatMessage(error, 'Unable to export'))).then();
     } finally {
       setExportLoading(false);
     }
   };
 
   const getVisibleColumns = () => {
-    const customRosterColumnInfos = [
+    const customRosterColumnInfos: ApiRosterColumnInfo[] = [
       ...rosterColumnInfos,
       {
         name: 'unitId',
@@ -328,6 +328,7 @@ export const MusterPage = () => {
         custom: false,
         required: false,
         updatable: false,
+        config: {},
       },
       {
         name: 'nonMusterPercent',
@@ -338,6 +339,7 @@ export const MusterPage = () => {
         custom: false,
         required: false,
         updatable: false,
+        config: {},
       },
     ];
 

--- a/src/components/pages/roster-columns-page/edit-column-dialog.styles.ts
+++ b/src/components/pages/roster-columns-page/edit-column-dialog.styles.ts
@@ -21,21 +21,12 @@ export default makeStyles((theme: Theme) => createStyles({
     lineHeight: '24px',
     color: '#A9AEB1',
   },
-  optionsHeaderLabel: {
-    marginTop: theme.spacing(3),
-  },
   flagTableBorder: {
     border: `1px solid ${theme.palette.text.hint}`,
     borderRadius: '4px',
   },
   typeSelect: {
     width: '100%',
-    '&:before': {
-      border: 'none',
-    },
-    '& option, & select': {
-      textTransform: 'capitalize',
-    },
   },
   addEnumButton: {
     borderColor: 'transparent',

--- a/src/components/pages/roster-columns-page/roster-columns-page-help.tsx
+++ b/src/components/pages/roster-columns-page/roster-columns-page-help.tsx
@@ -8,8 +8,7 @@ export const RosterColumnsPageHelp = () => {
         Create and manage custom columns that appear on your group’s roster.
       `}
       bullets={[
-        'Add, Edit, or Delete custom columns',
-        'Edit a custom column’s display name',
+        'Add or Delete custom columns',
         'Edit custom column flags (e.g. Contains PII, Required, Multiline, etc.)',
       ]}
     />

--- a/src/components/pages/roster-columns-page/roster-columns-page.tsx
+++ b/src/components/pages/roster-columns-page/roster-columns-page.tsx
@@ -90,7 +90,7 @@ export const RosterColumnsPage = () => {
           await initializeTable();
         },
         onError: (message: string) => {
-          dispatch(Modal.alert('Edit Column', `Unable to edit column: ${message}`));
+          dispatch(Modal.alert('Edit Column', `Unable to edit column: ${message}`)).then();
         },
       });
     }
@@ -111,7 +111,7 @@ export const RosterColumnsPage = () => {
     try {
       await axios.delete(`api/roster/${orgId}/column/${columnToDelete.name}`);
     } catch (error) {
-      dispatch(Modal.alert('Delete Column', formatMessage(error, 'Unable to delete column')));
+      dispatch(Modal.alert('Delete Column', formatMessage(error, 'Unable to delete column'))).then();
     }
     setColumnToDelete(null);
     await initializeTable();
@@ -156,8 +156,7 @@ export const RosterColumnsPage = () => {
           <Table aria-label="column table">
             <TableHead>
               <TableRow>
-                <TableCell>Field Name</TableCell>
-                <TableCell>Display Name</TableCell>
+                <TableCell>Name</TableCell>
                 <TableCell>Type</TableCell>
                 <TableCell className={classes.iconCell}>PII</TableCell>
                 <TableCell className={classes.iconCell}>PHI</TableCell>
@@ -168,7 +167,6 @@ export const RosterColumnsPage = () => {
             <TableBody>
               {columns.map(column => (
                 <TableRow key={column.name}>
-                  <TableCell component="th" scope="row">{column.name}</TableCell>
                   <TableCell>{column.displayName}</TableCell>
                   <TableCell className={classes.typeColumn}>{rosterColumnTypeDisplayName(column.type)}</TableCell>
                   <TableCell className={classes.iconCell}>


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200179840530508

I opted for camel casing the custom column `name` field based off of the `display` field because it does end up in the ES data, and I'd like it to be user readable. As a result, there's currently a UX pain point where you can't edit the display name of a custom column after creating it. However, we should be able to come back to that and fix it by automatically updating the ES data whenever the user changes a column name. We just don't have time for that detail right now.

I really wanted to refactor `name`/`display` in the CustomRosterColumn model to `key`/`displayName`, but I put it off for now since it would require an update to the processor, and I don't want to risk it. I've got it in my notes to come back to at some point.

There's an existing bug I noticed where the New/Edit Custom Column dialog changes size when you change the column type. I've got it in my notes as well.

## Updated New/Edit Custom Column Dialog
<img width="913" alt="Screen Shot 2021-04-15 at 4 15 48 PM" src="https://user-images.githubusercontent.com/3220897/114949458-ee00ff80-9e05-11eb-9588-de06c1161f3a.png">

<img width="774" alt="Screen Shot 2021-04-15 at 4 15 59 PM" src="https://user-images.githubusercontent.com/3220897/114949465-f0635980-9e05-11eb-9aef-0304be4f6252.png">
