### PR TITLE
Orphaned records paging and refactoring.

### DIFF
--- a/server/api/export/export.controller.ts
+++ b/server/api/export/export.controller.ts
@@ -14,7 +14,7 @@ import {
 import {
   ApiRequest,
   OrgParam,
-  PagedQuery,
+  PaginatedQuery,
 } from '../index';
 import { RosterEntryData } from '../roster/roster.controller';
 import { Roster } from '../roster/roster.model';
@@ -177,6 +177,6 @@ type ExportMusterIndividualsQuery = {
   interval: TimeInterval
   intervalCount: string
   unitId?: number
-} & PagedQuery;
+} & PaginatedQuery;
 
 export default new ExportController();

--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -95,9 +95,14 @@ export type OrgUnitParams = OrgParam & UnitParam;
 export type OrgSettingParams = OrgParam & SettingParam;
 export type OrgColumnParams = OrgParam & ColumnParam;
 
-export type PagedQuery = {
+export type PaginatedQuery = {
   limit: string
   page: string
+};
+
+export type Paginated<TData> = {
+  rows: TData[]
+  totalRowsCount: number
 };
 
 export default router;

--- a/server/api/muster/muster.controller.ts
+++ b/server/api/muster/muster.controller.ts
@@ -15,8 +15,10 @@ import {
   ApiRequest,
   OrgRoleParams,
   OrgUnitParams,
-  PagedQuery,
+  PaginatedQuery,
+  Paginated,
 } from '../index';
+import { Roster } from '../roster/roster.model';
 import {
   MusterConfiguration,
   Unit,
@@ -31,7 +33,7 @@ import {
 
 class MusterController {
 
-  async getIndividuals(req: ApiRequest<OrgRoleParams, null, GetIndividualsQuery>, res: Response) {
+  async getIndividuals(req: ApiRequest<OrgRoleParams, null, GetIndividualsQuery>, res: Response<Paginated<Partial<Roster>>>) {
     assertRequestQuery(req, [
       'interval',
       'intervalCount',
@@ -215,7 +217,7 @@ type GetIndividualsQuery = {
   interval: TimeInterval
   intervalCount: string
   unitId: number | null
-} & PagedQuery;
+} & PaginatedQuery;
 
 type GetTrendsQuery = {
   weeksCount?: string

--- a/server/api/roster/roster.controller.ts
+++ b/server/api/roster/roster.controller.ts
@@ -16,7 +16,8 @@ import {
   OrgColumnParams,
   OrgParam,
   OrgRosterParams,
-  PagedQuery,
+  Paginated,
+  PaginatedQuery,
 } from '../index';
 import { Roster } from './roster.model';
 import {
@@ -143,11 +144,11 @@ class RosterController {
     res.send(csvContents);
   }
 
-  async getRoster(req: ApiRequest<OrgParam, any, GetRosterQuery>, res: Response) {
+  async getRoster(req: ApiRequest<OrgParam, any, GetRosterQuery>, res: Response<Paginated<RosterEntryData>>) {
     res.json(await internalSearchRoster(req.query, req.appOrg!, req.appUserRole!));
   }
 
-  async searchRoster(req: ApiRequest<OrgParam, SearchRosterBody, GetRosterQuery>, res: Response) {
+  async searchRoster(req: ApiRequest<OrgParam, SearchRosterBody, GetRosterQuery>, res: Response<Paginated<RosterEntryData>>) {
     res.json(await internalSearchRoster(req.query, req.appOrg!, req.appUserRole!, req.body));
   }
 
@@ -493,7 +494,7 @@ function findColumnByName(name: string, columns: RosterColumnInfo[]): RosterColu
   return column;
 }
 
-async function internalSearchRoster(query: GetRosterQuery, org: Org, userRole: UserRole, searchParams?: SearchRosterBody) {
+async function internalSearchRoster(query: GetRosterQuery, org: Org, userRole: UserRole, searchParams?: SearchRosterBody): Promise<Paginated<RosterEntryData>> {
   const limit = parseInt(query.limit ?? '100');
   const page = parseInt(query.page ?? '0');
   const orderBy = query.orderBy || 'edipi';
@@ -601,7 +602,7 @@ interface RosterInfo {
 type GetRosterQuery = {
   orderBy?: string
   sortDirection?: 'ASC' | 'DESC'
-} & PagedQuery;
+} & PaginatedQuery;
 
 type QueryOp = '=' | '<>' | '~' | '>' | '<' | 'startsWith' | 'endsWith' | 'in' | 'between';
 

--- a/src/actions/orphaned-record.actions.ts
+++ b/src/actions/orphaned-record.actions.ts
@@ -1,43 +1,41 @@
 import { Dispatch } from 'redux';
 import { OrphanedRecordClient } from '../client';
-import { ApiOrphanedRecord } from '../models/api-response';
+import { ApiOrphanedRecordsPaginated } from '../models/api-response';
 
 export namespace OrphanedRecord {
 
   export namespace Actions {
 
     export class Clear {
-      static type = 'CLEAR_ORPHANED_RECORD';
+      static type = 'ORPHANED_RECORD_CLEAR';
       type = Clear.type;
     }
 
-    export class Fetch {
-      static type = 'FETCH_ORPHANED_RECORD';
-      type = Fetch.type;
+    export class FetchPage {
+      static type = 'ORPHANED_RECORD_FETCH_PAGE';
+      type = FetchPage.type;
     }
-    export class FetchSuccess {
-      static type = `${Fetch.type}_SUCCESS`;
-      type = FetchSuccess.type;
-      constructor(public payload: {
-        orphanedRecords: ApiOrphanedRecord[]
-      }) {}
+    export class FetchPageSuccess {
+      static type = `${FetchPage.type}_SUCCESS`;
+      type = FetchPageSuccess.type;
+      constructor(public payload: ApiOrphanedRecordsPaginated) {}
     }
-    export class FetchFailure {
-      static type = `${Fetch.type}_FAILURE`;
-      type = FetchFailure.type;
+    export class FetchPageFailure {
+      static type = `${FetchPage.type}_FAILURE`;
+      type = FetchPageFailure.type;
       constructor(public payload: {
         error: any
       }) { }
     }
   }
 
-  export const fetch = (orgId: number) => async (dispatch: Dispatch) => {
-    dispatch(new Actions.Fetch());
+  export const fetchPage = (orgId: number, page: number, limit: number) => async (dispatch: Dispatch) => {
+    dispatch(new Actions.FetchPage());
     try {
-      const orphanedRecords = await OrphanedRecordClient.fetchAll(orgId);
-      dispatch(new Actions.FetchSuccess({ orphanedRecords }));
+      const data = await OrphanedRecordClient.fetchPage(orgId, page, limit);
+      dispatch(new Actions.FetchPageSuccess(data));
     } catch (error) {
-      dispatch(new Actions.FetchFailure({ error }));
+      dispatch(new Actions.FetchPageFailure({ error }));
     }
   };
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -8,7 +8,7 @@ import {
   ApiAccessRequest,
   ApiDashboard,
   ApiNotification,
-  ApiOrphanedRecord,
+  ApiOrphanedRecordsPaginated,
   ApiReportSchema,
   ApiRole,
   ApiRosterColumnInfo,
@@ -112,8 +112,13 @@ export namespace ReportSchemaClient {
 }
 
 export namespace OrphanedRecordClient {
-  export const fetchAll = (orgId: number): Promise<ApiOrphanedRecord[]> => {
-    return client.get(`orphaned-record/${orgId}`);
+  export const fetchPage = (orgId: number, page: number, limit: number): Promise<ApiOrphanedRecordsPaginated> => {
+    return client.get(`orphaned-record/${orgId}`, {
+      params: {
+        page,
+        limit,
+      },
+    });
   };
 }
 

--- a/src/components/app-sidenav/app-sidenav.tsx
+++ b/src/components/app-sidenav/app-sidenav.tsx
@@ -76,7 +76,7 @@ const SidenavLink = (props: SidenavLinkProps) => {
       <ListItem button key={name}>
         <ListItemIcon>{icon}</ListItemIcon>
         <ListItemText primary={name} />
-        <Badge color={badgeColor} badgeContent={badgeContent} className={classes.badge} />
+        <Badge color={badgeColor} badgeContent={badgeContent} max={999} className={classes.badge} />
       </ListItem>
     </Link>
   );
@@ -88,7 +88,7 @@ export const AppSidenav = () => {
   const user = useSelector<AppState, UserState>(state => state.user);
   const orgId = useSelector(UserSelector.orgId);
   const appFrame = useSelector<AppState, AppFrameState>(state => state.appFrame);
-  const orphanedRecords = useSelector(OrphanedRecordSelector.all);
+  const orphanedRecords = useSelector(OrphanedRecordSelector.root);
 
   const toggleSidenav = () => {
     dispatch(AppFrame.toggleSidenavExpanded());
@@ -96,7 +96,8 @@ export const AppSidenav = () => {
 
   useEffect(() => {
     if (user.activeRole?.role.canManageRoster) {
-      dispatch(OrphanedRecord.fetch(orgId!));
+      // Set the limit to 0 here since we only need the total rows count for the Roster badge.
+      dispatch(OrphanedRecord.fetchPage(orgId!, 0, 0));
     } else {
       dispatch(OrphanedRecord.clear());
     }
@@ -166,7 +167,7 @@ export const AppSidenav = () => {
               to="/roster"
               name="Roster"
               icon={(<AssignmentIndIcon />)}
-              badgeContent={orphanedRecords.length}
+              badgeContent={orphanedRecords.totalRowsCount}
             />
           )}
         </List>

--- a/src/components/pages/home-page/home-page.tsx
+++ b/src/components/pages/home-page/home-page.tsx
@@ -112,7 +112,7 @@ export const HomePage = () => {
   const dispatch = useDispatch();
   const orgId = useSelector(UserSelector.orgId)!;
   const user = useSelector<AppState, UserState>(state => state.user);
-  const orphanedRecords = useSelector(OrphanedRecordSelector.all);
+  const orphanedRecords = useSelector(OrphanedRecordSelector.root);
   const [accessRequests, setAccessRequests] = useState<ApiAccessRequest[]>([]);
   const [musterNonComplianceLastTwoWeeks, setMusterNonComplianceLastTwoWeek] = useState<number[]>([1.0, 0.0]);
   const favoriteDashboards = useSelector(UserSelector.favoriteDashboards)!;
@@ -175,7 +175,7 @@ export const HomePage = () => {
   }, [orgId]);
 
   useEffect(() => {
-    initializeTable();
+    initializeTable().then();
   }, [initializeTable]);
 
   const nonComplianceDelta = musterNonComplianceLastTwoWeeks[1] - musterNonComplianceLastTwoWeeks[0];
@@ -240,7 +240,7 @@ export const HomePage = () => {
                     Orphaned Records
                   </Typography>
                   <Typography className={classes.metricValue}>
-                    {orphanedRecords.length}
+                    {orphanedRecords.totalRowsCount}
                   </Typography>
                   <Link to="/roster">View Now &rarr;</Link>
                 </CardContent>

--- a/src/components/pages/muster-page/muster-page.tsx
+++ b/src/components/pages/muster-page/muster-page.tsx
@@ -17,16 +17,27 @@ import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 import ToggleButton from '@material-ui/lab/ToggleButton';
 import * as Plotly from 'plotly.js';
 import React, {
-  ChangeEvent, MouseEvent, useCallback, useEffect, useState,
+  ChangeEvent,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useState,
 } from 'react';
 import axios from 'axios';
-import { useDispatch, useSelector } from 'react-redux';
+import {
+  useDispatch,
+  useSelector,
+} from 'react-redux';
 import Plot from 'react-plotly.js';
 import _ from 'lodash';
 import moment from 'moment';
 import { AppFrame } from '../../../actions/app-frame.actions';
 import { downloadFile } from '../../../utility/download';
-import { getMaxPageIndex, getNewPageIndex, columnInfosOrdered } from '../../../utility/table';
+import {
+  getMaxPageIndex,
+  getNewPageIndex,
+  columnInfosOrdered,
+} from '../../../utility/table';
 import PageHeader from '../../page-header/page-header';
 import { TableCustomColumnsContent } from '../../tables/table-custom-columns-content';
 import { TablePagination } from '../../tables/table-pagination/table-pagination';
@@ -35,7 +46,7 @@ import useStyles from './muster-page.styles';
 import { UserState } from '../../../reducers/user.reducer';
 import { AppState } from '../../../store';
 import {
-  ApiMusterIndividuals,
+  ApiMusterIndividualsPaginated,
   ApiMusterTrends,
   ApiRosterColumnInfo,
   ApiRosterColumnType,
@@ -112,7 +123,10 @@ export const MusterPage = () => {
     ...trendChart,
   };
 
-  const [individualsTimeRangeString, setIndividualsTimeRangeString] = useState(timeRangeToString({ interval: 'day', intervalCount: 1 }));
+  const [individualsTimeRangeString, setIndividualsTimeRangeString] = useState(timeRangeToString({
+    interval: 'day',
+    intervalCount: 1,
+  }));
   const [individualsUnitId, setIndividualsUnitId] = useState<number>(-1);
   const [individualsPage, setIndividualsPage] = useState(0);
   const [individualsRowsPerPage, setIndividualsRowsPerPage] = useState(10);
@@ -123,7 +137,10 @@ export const MusterPage = () => {
   const [monthlyTrendTopUnitCount, setMonthlyTrendTopUnitCount] = useState(5);
   const [weeklyTrendData, setWeeklyTrendData] = useState<Plotly.Data[]>([]);
   const [monthlyTrendData, setMonthlyTrendData] = useState<Plotly.Data[]>([]);
-  const [individualsData, setIndividualsData] = useState<ApiMusterIndividuals>({ rows: [], totalRowsCount: 0 });
+  const [individualsData, setIndividualsData] = useState<ApiMusterIndividualsPaginated>({
+    rows: [],
+    totalRowsCount: 0,
+  });
 
   const org = useSelector(UserSelector.org);
   const orgId = org?.id;
@@ -146,7 +163,7 @@ export const MusterPage = () => {
 
   const reloadTable = useCallback(async () => {
     const { interval, intervalCount } = stringToTimeRange(individualsTimeRangeString);
-    let data: ApiMusterIndividuals;
+    let data: ApiMusterIndividualsPaginated;
     try {
       data = (await axios.get(`api/muster/${orgId}/individuals`, {
         params: {
@@ -156,7 +173,7 @@ export const MusterPage = () => {
           page: individualsPage,
           limit: individualsRowsPerPage,
         },
-      })).data as ApiMusterIndividuals;
+      })).data as ApiMusterIndividualsPaginated;
     } catch (error) {
       showErrorDialog('Get Individuals', error);
       throw error;
@@ -217,7 +234,7 @@ export const MusterPage = () => {
 
   const getTrendData = useCallback((unitStatsByDate: ApiUnitStatsByDate, topUnitCount: number) => {
     // Sum up each unit's non-muster percent to figure out who's performing worst overall.
-    const nonMusterPercentSumByUnit = {} as {[unitName: string]: number};
+    const nonMusterPercentSumByUnit = {} as { [unitName: string]: number };
     for (const date of Object.keys(unitStatsByDate)) {
       for (const unitName of Object.keys(unitStatsByDate[date])) {
         if (nonMusterPercentSumByUnit[unitName] == null) {

--- a/src/models/api-response.ts
+++ b/src/models/api-response.ts
@@ -1,7 +1,7 @@
 import { DaysOfTheWeek } from '../utility/days';
 
-export interface ApiArrayPaginated {
-  rows: any[],
+export interface ApiPaginated<TData> {
+  rows: TData[],
   totalRowsCount: number,
 }
 
@@ -69,9 +69,7 @@ export interface ApiAccessRequest {
   status: 'approved' | 'pending' | 'denied',
 }
 
-export interface ApiRosterPaginated extends ApiArrayPaginated {
-  rows: ApiRosterEntry[],
-}
+export interface ApiRosterPaginated extends ApiPaginated<ApiRosterEntry> {}
 
 export enum ApiRosterColumnType {
   String = 'string',
@@ -155,17 +153,20 @@ export interface ApiRosterEntry {
 }
 
 export interface ApiOrphanedRecord {
-  id: string,
-  edipi: string,
-  phone: string,
-  unit: string,
-  count: number,
-  action?: string,
-  claimedUntil?: Date,
-  latestReportDate: Date,
-  earliestReportDate: Date,
-  unitId?: number,
+  id: string;
+  edipi: string;
+  phone: string;
+  unit: string;
+  count: number;
+  action?: string;
+  claimedUntil?: Date;
+  latestReportDate: Date;
+  earliestReportDate: Date;
+  unitId?: number;
+  rosterHistoryId?: number;
 }
+
+export interface ApiOrphanedRecordsPaginated extends ApiPaginated<ApiOrphanedRecord> {}
 
 export interface ApiWorkspaceTemplate {
   id: number,
@@ -201,9 +202,7 @@ export interface ApiUnitStatsByDate {
   }
 }
 
-export interface ApiMusterIndividuals extends ApiArrayPaginated {
-  rows: ApiRosterEntry[]
-}
+export interface ApiMusterIndividualsPaginated extends ApiPaginated<ApiRosterEntry> {}
 
 export interface ApiMusterTrends {
   weekly: ApiUnitStatsByDate

--- a/src/reducers/orphaned-record.reducer.ts
+++ b/src/reducers/orphaned-record.reducer.ts
@@ -2,13 +2,15 @@ import { OrphanedRecord } from '../actions/orphaned-record.actions';
 import { ApiOrphanedRecord } from '../models/api-response';
 
 export interface OrphanedRecordState {
-  orphanedRecords: ApiOrphanedRecord[],
+  rows: ApiOrphanedRecord[],
+  totalRowsCount: number
   isLoading: boolean
   lastUpdated: number
 }
 
 export const orphanedRecordInitialState: OrphanedRecordState = {
-  orphanedRecords: [],
+  rows: [],
+  totalRowsCount: 0,
   isLoading: false,
   lastUpdated: 0,
 };
@@ -18,30 +20,33 @@ export function orphanedRecordReducer(state = orphanedRecordInitialState, action
     case OrphanedRecord.Actions.Clear.type: {
       return {
         ...state,
-        orphanedRecords: [],
+        rows: [],
+        totalRowsCount: 0,
         isLoading: false,
         lastUpdated: Date.now(),
       };
     }
-    case OrphanedRecord.Actions.Fetch.type: {
+    case OrphanedRecord.Actions.FetchPage.type: {
       return {
         ...state,
         isLoading: true,
       };
     }
-    case OrphanedRecord.Actions.FetchSuccess.type: {
-      const payload = (action as OrphanedRecord.Actions.FetchSuccess).payload;
+    case OrphanedRecord.Actions.FetchPageSuccess.type: {
+      const { rows, totalRowsCount } = (action as OrphanedRecord.Actions.FetchPageSuccess).payload;
       return {
         ...state,
-        orphanedRecords: payload.orphanedRecords,
+        rows,
+        totalRowsCount,
         isLoading: false,
         lastUpdated: Date.now(),
       };
     }
-    case OrphanedRecord.Actions.FetchFailure.type: {
+    case OrphanedRecord.Actions.FetchPageFailure.type: {
       return {
         ...state,
-        orphanedRecords: [],
+        rows: [],
+        totalRowsCount: 0,
         isLoading: false,
       };
     }

--- a/src/selectors/orphaned-record.selector.ts
+++ b/src/selectors/orphaned-record.selector.ts
@@ -1,6 +1,6 @@
-import { ApiOrphanedRecord } from '../models/api-response';
+import { OrphanedRecordState } from '../reducers/orphaned-record.reducer';
 import { AppState } from '../store';
 
 export namespace OrphanedRecordSelector {
-  export const all = (state: AppState): ApiOrphanedRecord[] => state.orphanedRecord.orphanedRecords;
+  export const root = (state: AppState): OrphanedRecordState => state.orphanedRecord;
 }


### PR DESCRIPTION
The orphaned records table should have paging now, and should load/respond much faster when there are lots of orphaned records.

I refactored the roster page a bit, since it was sending off more requests than necessary on load, which seemed good to avoid considering how heavy duty the orphaned records query is.

I think there was also a bug in the orphaned record resolve endpoint, which should be fixed now. I was running into an issue where I was able to add one orphaned record to the roster, but when trying to add a second it would look as if it succeeded (removing the orphaned record) but wouldn't actually add the person to the roster. It looks like it was an issue where the `getRosterHistory()` function wasn't filtering by the edipi in the orphaned record, so it would find *any* roster history entry within the time range it was querying for, and if it found *anyone* it would assume that was the person you were resolving for. Let me know if I just misunderstood something though, or was maybe using bad test data.

If you want to try reproducing that bug, it should be possible if you add one orphaned record to the roster, then try adding another with a different edipi that has an older timestamp.