### PR TITLE
Orphaned record edit error and refactoring.

### DIFF
--- a/server/api/export/export.controller.ts
+++ b/server/api/export/export.controller.ts
@@ -16,7 +16,7 @@ import {
   OrgParam,
   PaginatedQuery,
 } from '../index';
-import { RosterEntryData } from '../roster/roster.controller';
+import { RosterEntryData } from '../roster/roster-entity';
 import { Roster } from '../roster/roster.model';
 import { Unit } from '../unit/unit.model';
 

--- a/server/api/orphaned-record/index.ts
+++ b/server/api/orphaned-record/index.ts
@@ -28,11 +28,19 @@ router.delete(
 );
 
 router.put(
-  '/:orgId/:orphanId/resolve',
+  '/:orgId/:orphanId/resolve-with-add',
   requireOrgAccess,
   requireRolePermission(role => role.canManageRoster),
   bodyParser.json(),
-  controller.resolveOrphanedRecord,
+  controller.resolveOrphanedRecordWithAdd,
+);
+
+router.put(
+  '/:orgId/:orphanId/resolve-with-edit',
+  requireOrgAccess,
+  requireRolePermission(role => role.canManageRoster),
+  bodyParser.json(),
+  controller.resolveOrphanedRecordWithEdit,
 );
 
 router.put(

--- a/server/api/orphaned-record/orphaned-record.controller.ts
+++ b/server/api/orphaned-record/orphaned-record.controller.ts
@@ -1,33 +1,36 @@
 import { Response } from 'express';
 import {
   Brackets,
-  getConnection,
+  getManager,
 } from 'typeorm';
-import { assertRequestQuery } from '../../util/api-utils';
+import {
+  assertRequestBody,
+  assertRequestQuery,
+} from '../../util/api-utils';
+import { BadRequestError } from '../../util/error-types';
+import { buildVisibleOrphanedRecordResultsQuery } from '../../util/orphaned-records-utils';
+import { convertDateParam } from '../../util/reingest-utils';
+import {
+  addRosterEntry,
+  editRosterEntry,
+} from '../../util/roster-utils';
 import {
   ApiRequest,
   OrgParam,
-  PaginatedQuery,
   Paginated,
+  PaginatedQuery,
 } from '../index';
-import { OrphanedRecord } from './orphaned-record.model';
+import { Org } from '../org/org.model';
+import {
+  RosterEntity,
+  RosterEntryData,
+} from '../roster/roster-entity';
+import { Roster } from '../roster/roster.model';
 import {
   ActionType,
   OrphanedRecordAction,
 } from './orphaned-record-action.model';
-import { Org } from '../org/org.model';
-import {
-  BadRequestError,
-  InternalServerError,
-} from '../../util/error-types';
-import {
-  convertDateParam,
-  reingestByDocumentId,
-} from '../../util/reingest-utils';
-import { RosterHistory } from '../roster/roster-history.model';
-import { RosterEntryData } from '../roster/roster.controller';
-import { addRosterEntry } from '../../util/roster-utils';
-import { Roster } from '../roster/roster.model';
+import { OrphanedRecord } from './orphaned-record.model';
 
 class OrphanedRecordController {
 
@@ -100,81 +103,102 @@ class OrphanedRecordController {
     res.json(result);
   }
 
-  async resolveOrphanedRecord(req: ApiRequest<OrphanedRecordResolveParam, RosterEntryData>, res: Response<OrphanedRecord>) {
+  async resolveOrphanedRecordWithAdd(req: ApiRequest<OrphanedRecordResolveParam, RosterEntryData>, res: Response) {
+    const compositeId = req.params.orphanId;
+    assertRequestBody(req, [
+      'edipi',
+      'unit',
+    ]);
+    const entryData = req.body;
+
     const orphanedRecords = await OrphanedRecord.find({
       where: {
-        compositeId: req.params.orphanId,
+        compositeId,
         deletedOn: null,
       },
     });
 
     if (orphanedRecords.length === 0) {
-      throw new BadRequestError(`Unable to locate orphaned record with id: ${req.params.orphanId}`);
-    }
-    if (orphanedRecords.length > 1) {
-      throw new BadRequestError(`Encountered Multiple Orphaned Records: ${req.params.orphanId}`);
+      throw new BadRequestError(`Unable to locate orphaned record with id: ${compositeId}`);
     }
 
-    const orphanedRecord = orphanedRecords[0];
-    const documentId = orphanedRecord.documentId;
-    let rosterHistory: RosterHistory[] = [];
-
-    if (req.body.unit) {
-      rosterHistory = await getRosterHistoryForOrphanedRecord(orphanedRecord, req.body.unit);
-    }
-
-    let newRosterEntry: Roster | undefined;
-    if (!rosterHistory.length) {
-      // Add a new roster entry since the orphaned record
-      // doesn't correspond to an existing roster entry
-      newRosterEntry = await addRosterEntry(req.appOrg!, req.appUserRole!.role, req.body);
-      rosterHistory = await getRosterHistoryForOrphanedRecord(orphanedRecord, newRosterEntry.unit.id);
-    }
-
-    if (!rosterHistory.length) {
-      throw new InternalServerError('Unable to locate RosterHistory record.');
-    }
+    // We have to modify the roster outside of the transaction, since the orphaned record resolve process
+    // depends on having the latest roster history from this addition.
+    const entry = await getManager().transaction(async manager => {
+      return addRosterEntry(req.appOrg!, req.appUserRole!.role, entryData, manager);
+    });
 
     try {
-      await getConnection().transaction(async manager => {
-        let timestamp = Math.min(...orphanedRecords.map(x => x.timestamp.getTime()));
-        for (const item of rosterHistory) {
-          // Backdate the timestamp to the earliest orphaned record time.
-          item.timestamp = new Date(
-            Math.min(item.timestamp.getTime(), timestamp),
-          );
-
-          // Ensure that two records don't have the same value
-          timestamp -= 1;
+      await getManager().transaction(async manager => {
+        for (const orphanedRecord of orphanedRecords) {
+          await orphanedRecord.resolve(entry, manager);
         }
-
-        // Save the updated timestamp
-        await manager.save(rosterHistory);
-
-        // Remove the orphan record entry
-        await manager.softRemove(orphanedRecord);
-
-        // Delete any outstanding actions
-        await manager
-          .createQueryBuilder()
-          .delete()
-          .from(OrphanedRecordAction)
-          .where(`id=:id`, { id: req.params.orphanId })
-          .orWhere('expires_on < now()')
-          .execute();
       });
     } catch (err) {
-      if (newRosterEntry) {
-        await newRosterEntry.remove();
-      }
+      // If something went wrong we have to rollback the new entry manually.
+      await entry.remove();
+
       throw err;
     }
 
-    // Request a reingestion of a single document. Don't await on this since it may take a while
-    // and can safely run in the background.
-    reingestByDocumentId(documentId).then();
+    res.status(200).send();
+  }
 
-    res.json(orphanedRecord);
+  async resolveOrphanedRecordWithEdit(req: ApiRequest<OrphanedRecordResolveParam, ResolveWithEditBody>, res: Response) {
+    const compositeId = req.params.orphanId;
+    assertRequestBody(req, [
+      'edipi',
+      'unit',
+    ]);
+    const { id: entryId, ...entryData } = req.body;
+
+    const orphanedRecords = await OrphanedRecord.find({
+      where: {
+        compositeId,
+        deletedOn: null,
+      },
+    });
+
+    if (orphanedRecords.length === 0) {
+      throw new BadRequestError(`Unable to locate orphaned record with id: ${compositeId}`);
+    }
+
+    // Save out the old entry data in case something goes wrong and we need to rollback.
+    const oldEntry = await Roster.findOne({
+      relations: ['unit'],
+      where: {
+        id: entryId,
+      },
+    });
+
+    if (!oldEntry) {
+      throw new BadRequestError(`Unable to locate roster entry with id: ${entryId}`);
+    }
+
+    const oldEntryData = oldEntry.toData();
+
+    // We have to modify the roster outside of the transaction, since the orphaned record resolve process
+    // depends on having the latest roster history from this addition.
+    const entry = await getManager().transaction(async manager => {
+      return editRosterEntry(req.appOrg!, req.appUserRole!, entryId, entryData, manager);
+    });
+
+    try {
+      await getManager().transaction(async manager => {
+        for (const orphanedRecord of orphanedRecords) {
+          await orphanedRecord.resolve(entry, manager);
+        }
+      });
+    } catch (err) {
+      // If something went wrong we have to rollback the entry manually.
+      await getManager().transaction(async manager => {
+        await editRosterEntry(req.appOrg!, req.appUserRole!, entryId, oldEntryData, manager);
+      });
+
+      throw err;
+    }
+
+    res.status(200).send();
   }
 
   async addOrphanedRecordAction(req: ApiRequest<OrphanedRecordActionParam, OrphanedRecordActionData>, res: Response) {
@@ -244,68 +268,6 @@ class OrphanedRecordController {
   }
 
 }
-
-async function getRosterHistoryForOrphanedRecord(orphanedRecord: OrphanedRecord, unitId: number) {
-  return RosterHistory.createQueryBuilder('rh')
-    .where('rh.unit_id = :unitId', { unitId })
-    .andWhere('rh.edipi = :edipi', { edipi: orphanedRecord.edipi })
-    .addOrderBy('rh.edipi', 'DESC')
-    .addOrderBy('rh.change_type', 'DESC')
-    .getMany();
-}
-
-function buildVisibleOrphanedRecordResultsQuery(userEdipi: string, orgId: number) {
-  const params = {
-    now: new Date(),
-    orgId,
-    userEdipi,
-  };
-
-  const rosterEntries = RosterHistory.createQueryBuilder('rh')
-    .leftJoin('rh.unit', 'u')
-    .select('rh.id', 'id')
-    .addSelect('rh.edipi', 'edipi')
-    .addSelect('rh.timestamp', 'timestamp')
-    .addSelect('rh.change_type', 'change_type')
-    .addSelect('rh.unit_id', 'unit_id')
-    .where('u.org_id = :orgId', { orgId })
-    .distinctOn(['rh.unit_id', 'rh.edipi'])
-    .orderBy('rh.unit_id')
-    .addOrderBy('rh.edipi', 'DESC')
-    .addOrderBy('rh.timestamp', 'DESC')
-    .addOrderBy('rh.change_type', 'DESC');
-
-  return OrphanedRecord.createQueryBuilder('orphan')
-    .leftJoin(OrphanedRecordAction, 'action', `action.id=orphan.composite_id AND (action.expires_on > :now OR action.expires_on IS NULL) AND (action.type='claim' OR (action.user_edipi=:userEdipi AND action.type='ignore'))`, params)
-    .leftJoin(`(${rosterEntries.getQuery()})`, 'roster', 'orphan.edipi = roster.edipi')
-    .where('orphan.org_id=:orgId', params)
-    .andWhere('orphan.deleted_on IS NULL')
-    .andWhere(`(roster.change_type IS NULL OR (roster.change_type <> 'deleted'))`)
-    .andWhere(`(action.type IS NULL OR (action.type='claim' AND action.user_edipi=:userEdipi))`, params)
-    .select('orphan.edipi', 'edipi')
-    .addSelect('orphan.unit', 'unit')
-    .addSelect('orphan.phone', 'phone')
-    .addSelect('action.type', 'action')
-    .addSelect('action.expires_on', 'claimedUntil')
-    .addSelect('MAX(orphan.timestamp)', 'latestReportDate')
-    .addSelect('MIN(orphan.timestamp)', 'earliestReportDate')
-    .addSelect('COUNT(*)::INTEGER', 'count')
-    .addSelect('orphan.composite_id', 'id')
-    .addSelect('roster.unit_id', 'unitId')
-    .addSelect('roster.id', 'rosterHistoryId')
-    .orderBy('orphan.count', 'DESC')
-    .addOrderBy('orphan.unit', 'ASC')
-    .addOrderBy('orphan.edipi', 'ASC')
-    .groupBy('orphan.composite_id')
-    .addGroupBy('orphan.edipi')
-    .addGroupBy('orphan.unit')
-    .addGroupBy('orphan.phone')
-    .addGroupBy('action.type')
-    .addGroupBy('action.expires_on')
-    .addGroupBy('roster.unit_id')
-    .addGroupBy('roster.id');
-}
-
 interface OrphanedRecordResult {
   id: string;
   edipi: string;
@@ -345,5 +307,9 @@ export interface OrphanedRecordActionData {
 export interface OrphanedRecordDeleteActionData extends OrphanedRecordActionParam {
   action: ActionType,
 }
+
+type ResolveWithEditBody = RosterEntryData & {
+  id: RosterEntity['id']
+};
 
 export default new OrphanedRecordController();

--- a/server/api/orphaned-record/orphaned-record.model.mock.ts
+++ b/server/api/orphaned-record/orphaned-record.model.mock.ts
@@ -1,0 +1,34 @@
+import moment from 'moment';
+import {
+  uniqueEdipi,
+  uniqueInt,
+  uniquePhone,
+  uniqueString,
+} from '../../util/test-utils/unique';
+import { Org } from '../org/org.model';
+import { OrphanedRecord } from './orphaned-record.model';
+
+export function mockOrphanedRecord(org: Org, customData?: Partial<OrphanedRecord>) {
+  return OrphanedRecord.create({
+    org,
+    edipi: uniqueEdipi(),
+    unit: uniqueString(),
+    phone: uniquePhone(),
+    timestamp: moment().subtract(uniqueInt(), 'hours').toDate(),
+    documentId: uniqueString(),
+    ...customData,
+  });
+}
+
+export function seedOrphanedRecords(org: Org, options: {
+  count: number,
+  customData?: Partial<OrphanedRecord>,
+}) {
+  const { count, customData } = options;
+  const orphanedRecords: OrphanedRecord[] = [];
+  for (let i = 0; i < count; i++) {
+    const orphan = mockOrphanedRecord(org, customData);
+    orphanedRecords.push(orphan);
+  }
+  return OrphanedRecord.save(orphanedRecords);
+}

--- a/server/api/orphaned-record/orphaned-record.model.ts
+++ b/server/api/orphaned-record/orphaned-record.model.ts
@@ -43,10 +43,10 @@ export class OrphanedRecord extends BaseEntity {
   org?: Org;
 
   @Column()
-  unit: string;
+  unit!: string;
 
   @Column()
-  phone: string;
+  phone!: string;
 
   @Column({
     type: 'timestamp',

--- a/server/api/orphaned-record/orphaned-record.model.ts
+++ b/server/api/orphaned-record/orphaned-record.model.ts
@@ -5,13 +5,18 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  EntityManager,
   JoinColumn,
   ManyToOne,
   PrimaryColumn,
 } from 'typeorm';
 import { InternalServerError } from '../../util/error-types';
+import { reingestByDocumentId } from '../../util/reingest-utils';
+import { getRosterHistoryForIndividual } from '../../util/roster-utils';
 import { timestampColumnTransformer } from '../../util/util';
 import { Org } from '../org/org.model';
+import { RosterEntity } from '../roster/roster-entity';
+import { OrphanedRecordAction } from './orphaned-record-action.model';
 
 @Entity()
 export class OrphanedRecord extends BaseEntity {
@@ -74,4 +79,48 @@ export class OrphanedRecord extends BaseEntity {
     }
     this.compositeId = `${this.edipi};${this.org!.id};${this.phone};${this.unit}`;
   }
+
+  async resolve(entry: RosterEntity, manager: EntityManager) {
+    await this.backdateRosterHistory(entry, manager);
+
+    await manager.softRemove(this);
+
+    await this.deleteActions(manager);
+
+    // Request a reingestion of a single document. Don't await on this since it may take a while
+    // and can safely run in the background.
+    reingestByDocumentId(this.documentId).then();
+  }
+
+  private deleteActions(manager: EntityManager) {
+    return manager.createQueryBuilder()
+      .delete()
+      .from(OrphanedRecordAction)
+      .where(`id=:id`, { id: this.compositeId })
+      .orWhere('expires_on < now()')
+      .execute();
+  }
+
+  private async backdateRosterHistory(entry: RosterEntity, manager: EntityManager) {
+    const rosterHistory = await getRosterHistoryForIndividual(this.edipi, entry.unit.id);
+    if (!rosterHistory.length) {
+      throw new InternalServerError('Unable to locate RosterHistory record.');
+    }
+
+    let timestamp = this.timestamp.getTime();
+
+    for (const historyEntry of rosterHistory) {
+      // Only update history entries that were after the orphaned record's timestamp.
+      historyEntry.timestamp = new Date(
+        Math.min(historyEntry.timestamp.getTime(), timestamp),
+      );
+
+      // Ensure that two records don't have the same value
+      timestamp -= 1;
+    }
+
+    await manager.save(rosterHistory);
+  }
+
 }
+

--- a/server/api/roster/custom-roster-column.model.mock.ts
+++ b/server/api/roster/custom-roster-column.model.mock.ts
@@ -8,10 +8,12 @@ export function mockCustomRosterColumn(org: Org, options?: {
 }) {
   const { customData } = options ?? {};
 
+  const name = uniqueString();
+
   return CustomRosterColumn.create({
-    name: uniqueString(),
+    name,
     org,
-    display: uniqueString(),
+    display: name,
     type: RosterColumnType.String,
     pii: true,
     phi: true,

--- a/server/api/roster/roster-entity.ts
+++ b/server/api/roster/roster-entity.ts
@@ -9,7 +9,6 @@ import {
   RequiredColumnError,
 } from '../../util/error-types';
 import {
-  BaseType,
   dateFromString,
   getOptionalValue,
   getRequiredValue,
@@ -144,24 +143,14 @@ export class RosterEntity extends BaseEntity {
   }
 
   setColumnValueFromData(column: RosterColumnInfo, data: RosterEntryData) {
-    // Get dates and enums as strings.
-    let paramType: BaseType;
-    switch (column.type) {
-      case RosterColumnType.Date:
-      case RosterColumnType.DateTime:
-      case RosterColumnType.Enum:
-        paramType = 'string';
-        break;
-      default:
-        paramType = column.type;
-    }
+    const expectedType = columnTypeToEntryDataType(column.type);
 
     // Get the column value from the data.
     let value: RosterColumnValue | undefined;
     if (column.required) {
-      value = getRequiredValue(column.name, data, paramType);
+      value = getRequiredValue(column.name, data, expectedType);
     } else {
-      value = getOptionalValue(column.name, data, paramType);
+      value = getOptionalValue(column.name, data, expectedType);
     }
 
     this.setColumnValue(column, value);
@@ -182,6 +171,18 @@ export class RosterEntity extends BaseEntity {
     this.setColumnValue(column, value);
   }
 
+}
+
+function columnTypeToEntryDataType(columnType: RosterColumnType) {
+  // Get dates and enums as strings.
+  switch (columnType) {
+    case RosterColumnType.Date:
+    case RosterColumnType.DateTime:
+    case RosterColumnType.Enum:
+      return 'string';
+    default:
+      return columnType;
+  }
 }
 
 export const baseRosterColumns: RosterColumnInfo[] = [
@@ -225,5 +226,5 @@ export type RosterEntryData = {
 } & CustomColumns;
 
 export type RosterFileRow = {
-  [key: string]: string
+  [columnName: string]: string
 };

--- a/server/api/roster/roster-entity.ts
+++ b/server/api/roster/roster-entity.ts
@@ -1,8 +1,26 @@
 import {
-  BaseEntity, Column, ManyToOne, PrimaryGeneratedColumn,
+  BaseEntity,
+  Column,
+  ManyToOne,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
-import { CustomColumns, RosterColumnInfo, RosterColumnType } from './roster.types';
+import {
+  BadRequestError,
+  RequiredColumnError,
+} from '../../util/error-types';
+import {
+  BaseType,
+  dateFromString,
+  getOptionalValue,
+  getRequiredValue,
+} from '../../util/util';
 import { Unit } from '../unit/unit.model';
+import {
+  CustomColumns,
+  RosterColumnInfo,
+  RosterColumnType,
+  RosterColumnValue,
+} from './roster.types';
 
 /**
  * This class serves as the base entity for both Roster and RosterHistory.  This allows both Roster and RosterHistory
@@ -35,18 +53,135 @@ export class RosterEntity extends BaseEntity {
   })
   lastName!: string;
 
+  // The get/set column functions abstract this json data structure away and treat
+  // custom columns as if they were directly on the model.
+  // This column should ONLY be modified in the setColumn() function.
   @Column('json', {
     nullable: false,
     default: '{}',
   })
   customColumns!: CustomColumns;
 
+  toData(): RosterEntryData {
+    if (!this.unit) {
+      throw new Error('You must have the roster entry unit loaded to convert to data.');
+    }
+
+    const entryData: RosterEntryData = {
+      edipi: this.edipi,
+      unit: this.unit.id,
+      firstName: this.firstName,
+      lastName: this.lastName,
+    };
+
+    for (const columnName of Object.keys(this.customColumns ?? {})) {
+      entryData[columnName] = this.customColumns[columnName];
+    }
+
+    return entryData;
+  }
+
   getColumnValue(column: RosterColumnInfo) {
     if (column.custom) {
-      return this.customColumns[column.name] || null;
+      return this.customColumns?.[column.name];
     }
-    return Reflect.get(this, column.name) || null;
+
+    return Reflect.get(this, column.name);
   }
+
+  setColumnValue(column: RosterColumnInfo, value: RosterColumnValue | undefined) {
+    // Ignore undefined values, unless this is a required column with no current value.
+    if (value === undefined) {
+      if (column.required && this.getColumnValue(column) != null) {
+        throw new RequiredColumnError(column.name);
+      }
+
+      return;
+    }
+
+    // Don't allow non-updatable columns to be updated if they already have a value.
+    if (!column.updatable && this.getColumnValue(column) !== undefined) {
+      throw new Error(`Column '${column.name}' is not updatable.`);
+    }
+
+    // If this is a null or empty value, make sure it's not a required column.
+    if (value === null || (typeof value === 'string' && value.length === 0)) {
+      if (column.required) {
+        throw new RequiredColumnError(column.name);
+      }
+    }
+
+    // Convert string data into the type our model expects.
+    if (typeof value === 'string' && column.type !== RosterColumnType.String) {
+      switch (column.type) {
+        case RosterColumnType.Number:
+          value = +value;
+          if (Number.isNaN(value)) {
+            throw new BadRequestError(`Number value for column '${column.name}' is invalid.`);
+          }
+          break;
+        case RosterColumnType.Date:
+        case RosterColumnType.DateTime:
+          value = dateFromString(value, true)!.toISOString();
+          break;
+        case RosterColumnType.Boolean:
+          value = (value === 'true');
+          break;
+        default:
+          break;
+      }
+    }
+
+    // Set the value.
+    if (column.custom) {
+      if (!this.customColumns) {
+        this.customColumns = {};
+      }
+      this.customColumns[column.name] = value;
+    } else {
+      Reflect.set(this, column.name, value);
+    }
+  }
+
+  setColumnValueFromData(column: RosterColumnInfo, data: RosterEntryData) {
+    // Get dates and enums as strings.
+    let paramType: BaseType;
+    switch (column.type) {
+      case RosterColumnType.Date:
+      case RosterColumnType.DateTime:
+      case RosterColumnType.Enum:
+        paramType = 'string';
+        break;
+      default:
+        paramType = column.type;
+    }
+
+    // Get the column value from the data.
+    let value: RosterColumnValue | undefined;
+    if (column.required) {
+      value = getRequiredValue(column.name, data, paramType);
+    } else {
+      value = getOptionalValue(column.name, data, paramType);
+    }
+
+    this.setColumnValue(column, value);
+  }
+
+  setColumnValueFromFileRow(column: RosterColumnInfo, row: RosterFileRow, edipiColumnName: string) {
+    // Allow a custom edipi column name.
+    const columnName = (column.name === 'edipi') ? edipiColumnName : column.name;
+
+    // Get the string value from the row data.
+    let value: string | null | undefined;
+    if (column.required) {
+      value = getRequiredValue(columnName, row, 'string', column.displayName);
+    } else {
+      value = getOptionalValue(columnName, row, 'string', column.displayName);
+    }
+
+    this.setColumnValue(column, value);
+  }
+
 }
 
 export const baseRosterColumns: RosterColumnInfo[] = [
@@ -59,7 +194,8 @@ export const baseRosterColumns: RosterColumnInfo[] = [
     custom: false,
     required: true,
     updatable: false,
-  }, {
+  },
+  {
     name: 'firstName',
     displayName: 'First Name',
     type: RosterColumnType.String,
@@ -68,7 +204,8 @@ export const baseRosterColumns: RosterColumnInfo[] = [
     custom: false,
     required: true,
     updatable: true,
-  }, {
+  },
+  {
     name: 'lastName',
     displayName: 'Last Name',
     type: RosterColumnType.String,
@@ -79,3 +216,14 @@ export const baseRosterColumns: RosterColumnInfo[] = [
     updatable: true,
   },
 ];
+
+export type RosterEntryData = {
+  edipi: RosterEntity['edipi'],
+  unit: number,
+  firstName?: RosterEntity['firstName'],
+  lastName?: RosterEntity['lastName'],
+} & CustomColumns;
+
+export type RosterFileRow = {
+  [key: string]: string
+};

--- a/server/api/roster/roster-entity.ts
+++ b/server/api/roster/roster-entity.ts
@@ -92,7 +92,7 @@ export class RosterEntity extends BaseEntity {
   setColumnValue(column: RosterColumnInfo, value: RosterColumnValue | undefined) {
     // Ignore undefined values, unless this is a required column with no current value.
     if (value === undefined) {
-      if (column.required && this.getColumnValue(column) != null) {
+      if (column.required && this.getColumnValue(column) !== undefined) {
         throw new RequiredColumnError(column.name);
       }
 

--- a/server/api/roster/roster.controller.spec.ts
+++ b/server/api/roster/roster.controller.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import FormData from 'form-data';
+import _ from 'lodash';
 import { expectNoErrors } from '../../util/test-utils/expect';
 import {
   seedOrgContact,
@@ -72,8 +73,7 @@ describe(`Roster Controller`, () => {
       });
 
       const body = {
-        name: uniqueString(),
-        displayName: uniqueString(),
+        displayName: 'Some Column Name',
         type: RosterColumnType.String,
         pii: true,
         phi: true,
@@ -97,7 +97,7 @@ describe(`Roster Controller`, () => {
       expect(columnAfter).to.exist;
       expect(columnAfter.org!.id).to.equal(org.id);
       expect(columnAfter).to.containSubset({
-        name: body.name,
+        name: _.camelCase(body.displayName),
         display: body.displayName,
         type: body.type,
         pii: body.pii,
@@ -120,8 +120,6 @@ describe(`Roster Controller`, () => {
       const column = await seedCustomRosterColumn(org);
 
       const body = {
-        displayName: uniqueString(),
-        type: RosterColumnType.Boolean,
         pii: !column.pii,
         phi: !column.phi,
         required: !column.required,
@@ -139,8 +137,6 @@ describe(`Roster Controller`, () => {
         org,
       }))!;
       expect(columnAfter).to.containSubset({
-        display: body.displayName,
-        type: body.type,
         pii: body.pii,
         phi: body.phi,
         required: body.required,
@@ -237,8 +233,7 @@ describe(`Roster Controller`, () => {
       expectNoErrors(res);
       expect(res.data).to.be.a('string');
       const csvHeaderParts = res.data.split('\n')[0].split(',');
-      expect(csvHeaderParts).to.include('unit');
-      expect(csvHeaderParts).to.include.members(baseRosterColumns.map(x => x.name));
+      expect(csvHeaderParts).to.include.members(['Unit', 'DoD ID', 'First Name', 'Last Name', customColumn.display]);
       expect(csvHeaderParts).to.include(customColumn.name);
     });
 

--- a/server/api/roster/roster.controller.ts
+++ b/server/api/roster/roster.controller.ts
@@ -1,15 +1,26 @@
-import { Response } from 'express';
 import csv from 'csvtojson';
+import { Response } from 'express';
 import fs from 'fs';
+import moment from 'moment';
 import {
-  getConnection,
+  getManager,
   In,
   OrderByCondition,
   SelectQueryBuilder,
 } from 'typeorm';
-import _ from 'lodash';
-import moment from 'moment';
 import { assertRequestBody } from '../../util/api-utils';
+import {
+  BadRequestError,
+  NotFoundError,
+  RosterUploadError,
+  RosterUploadErrorInfo,
+  UnprocessableEntity,
+} from '../../util/error-types';
+import {
+  addRosterEntry,
+  editRosterEntry,
+} from '../../util/roster-utils';
+import { dateFromString } from '../../util/util';
 import {
   ApiRequest,
   EdipiParam,
@@ -19,39 +30,27 @@ import {
   Paginated,
   PaginatedQuery,
 } from '../index';
-import { Roster } from './roster.model';
-import {
-  BadRequestError,
-  NotFoundError,
-  RosterUploadError,
-  RosterUploadErrorInfo,
-  UnprocessableEntity,
-} from '../../util/error-types';
-import {
-  dateFromString,
-  getOptionalParam,
-  getRequiredParam,
-} from '../../util/util';
 import { Org } from '../org/org.model';
+import { Unit } from '../unit/unit.model';
+import { UserRole } from '../user/user-role.model';
 import {
   CustomColumnData,
   CustomRosterColumn,
 } from './custom-roster-column.model';
-import { Unit } from '../unit/unit.model';
 import {
-  CustomColumnValue,
-  RosterColumnInfo,
-  RosterColumnType,
-} from './roster.types';
-import { UserRole } from '../user/user-role.model';
+  RosterEntryData,
+  RosterFileRow,
+} from './roster-entity';
 import {
   ChangeType,
   RosterHistory,
 } from './roster-history.model';
+import { Roster } from './roster.model';
 import {
-  addRosterEntry,
-  setRosterParamsFromBody,
-} from '../../util/roster-utils';
+  RosterColumnValue,
+  RosterColumnInfo,
+  RosterColumnType,
+} from './roster.types';
 
 class RosterController {
 
@@ -170,21 +169,18 @@ class RosterController {
     }
 
     const orgUnits = await req.appUserRole?.getUnits();
-
     if (!orgUnits) {
-      throw new BadRequestError('No units found.');
+      throw new BadRequestError('No units found in org.');
     }
 
     if (roster.length === 0) {
-      res.json({
-        count: 0,
-      });
+      res.json({ count: 0 });
       return;
     }
 
     const edipiKey = ['DoD ID', 'edipi', 'EDIPI'].find(t => t in roster[0]);
     if (!edipiKey) {
-      throw new BadRequestError('No edipi/DoD ID column.');
+      throw new BadRequestError('No edipi/DoD ID column in file.');
     }
 
     const columns = await Roster.getAllowedColumns(org, req.appUserRole!.role);
@@ -209,6 +205,7 @@ class RosterController {
     roster.forEach((row, index) => {
       const units = orgUnits.filter(u => row.unit === u.name || row.Unit === u.name);
       const unit = units.length > 0 ? units[0] : undefined;
+
       // Pre-validate / check for row-level issues.
       try {
         if (!(row.unit ?? row.Unit)) {
@@ -226,13 +223,16 @@ class RosterController {
 
       const entry = new Roster();
       entry.unit = unit!;
+
       for (const column of columns) {
         try {
-          setColumnFromCSV(entry, row, column, edipiKey);
+          entry.setColumnValueFromFileRow(column, row, edipiKey);
         } catch (error) {
-          onError(error, row, index, column.name === 'edipi' ? edipiKey : column.name);
+          const columnName = (column.name === 'edipi') ? edipiKey : column.name;
+          onError(error, row, index, columnName);
         }
       }
+
       rosterEntries.push(entry);
     });
 
@@ -303,7 +303,7 @@ class RosterController {
       const columns = (await Roster.getColumns(roster.unit.org!.id)).map(column => ({
         ...column,
         value: roster.getColumnValue(column),
-      } as RosterColumnWithValue));
+      } as RosterColumnInfoWithValue));
 
       const rosterInfo: RosterInfo = {
         unit: roster.unit,
@@ -318,7 +318,9 @@ class RosterController {
   }
 
   async addRosterEntry(req: ApiRequest<OrgParam, RosterEntryData>, res: Response) {
-    const newRosterEntry = await addRosterEntry(req.appOrg!, req.appUserRole!.role, req.body);
+    const newRosterEntry = await getManager().transaction(async manager => {
+      return addRosterEntry(req.appOrg!, req.appUserRole!.role, req.body, manager);
+    });
     res.status(201).json(newRosterEntry);
   }
 
@@ -357,43 +359,18 @@ class RosterController {
   }
 
   async updateRosterEntry(req: ApiRequest<OrgRosterParams, RosterEntryData>, res: Response) {
-    const rosterId = req.params.rosterId;
+    const entryId = parseInt(req.params.rosterId);
 
-    let entry = await Roster.findOne({
-      relations: ['unit'],
-      where: {
-        id: rosterId,
-      },
+    const entry = await getManager().transaction(async manager => {
+      return editRosterEntry(req.appOrg!, req.appUserRole!, entryId, req.body, manager);
     });
 
-    let updatedRosterEntry: Roster | null = null;
-    await getConnection().transaction(async manager => {
-      if (!entry) {
-        throw new NotFoundError('User could not be found.');
-      }
-
-      if (req.body.unit && req.body.unit !== entry.unit!.id) {
-        // If the unit changed, delete the individual from the old unit's roster.
-        const unit = await req.appUserRole?.getUnit(req.body.unit);
-        if (!unit) {
-          throw new NotFoundError(`Unit with ID ${req.body.unit} could not be found.`);
-        }
-        const newEntry = copyRosterEntry(entry);
-        await manager.delete(Roster, entry.id);
-        entry = newEntry;
-        entry.unit = unit;
-      }
-
-      const columns = await Roster.getAllowedColumns(req.appOrg!, req.appUserRole!.role);
-      await setRosterParamsFromBody(req.appOrg!, entry, req.body, columns);
-      updatedRosterEntry = await manager.save(entry);
-    });
-    res.json(updatedRosterEntry);
+    res.json(entry);
   }
 
 }
 
-const formatValue = (val: CustomColumnValue, column: RosterColumnInfo) => {
+const formatValue = (val: RosterColumnValue, column: RosterColumnInfo) => {
   if (val === null) {
     return val;
   }
@@ -533,65 +510,8 @@ async function internalSearchRoster(query: GetRosterQuery, org: Org, userRole: U
   };
 }
 
-function copyRosterEntry(roster: Roster) {
-  const newEntry = new Roster();
-  newEntry.edipi = roster.edipi;
-  newEntry.unit = roster.unit;
-  newEntry.firstName = roster.firstName;
-  newEntry.lastName = roster.lastName;
-  newEntry.customColumns = _.cloneDeep(roster.customColumns);
-  return newEntry;
-}
-
-function setColumnFromCSV(roster: Roster, row: RosterFileRow, column: RosterColumnInfo, edipiKey: string) {
-  let stringValue: string | undefined;
-  const columnName = column.name === 'edipi' ? edipiKey : column.name;
-  if (column.required) {
-    stringValue = getRequiredParam(columnName, row, 'string', column.displayName);
-  } else {
-    stringValue = getOptionalParam(columnName, row, 'string', column.displayName);
-  }
-  if (stringValue != null && stringValue.length > 0) {
-    let value: any;
-    switch (column.type) {
-      case RosterColumnType.String:
-        value = stringValue;
-        break;
-      case RosterColumnType.Number:
-        if (stringValue.length > 0) {
-          value = +stringValue;
-        }
-        break;
-      case RosterColumnType.Date:
-      case RosterColumnType.DateTime:
-        value = dateFromString(stringValue);
-        break;
-      case RosterColumnType.Boolean:
-        value = stringValue === 'true';
-        break;
-      default:
-        break;
-    }
-
-    if (column.required && value === undefined) {
-      throw new BadRequestError(`Invalid value (${stringValue}) for ${columnName}`);
-    }
-
-    if (value !== undefined) {
-      if (column.custom) {
-        if (!roster.customColumns) {
-          roster.customColumns = {};
-        }
-        roster.customColumns[column.name] = value;
-      } else {
-        Reflect.set(roster, column.name, value);
-      }
-    }
-  }
-}
-
-interface RosterColumnWithValue extends RosterColumnInfo {
-  value: CustomColumnValue,
+interface RosterColumnInfoWithValue extends RosterColumnInfo {
+  value: RosterColumnValue,
 }
 
 interface RosterInfo {
@@ -608,7 +528,7 @@ type QueryOp = '=' | '<>' | '~' | '>' | '<' | 'startsWith' | 'endsWith' | 'in' |
 
 type SearchRosterBodyEntry = {
   op: QueryOp
-  value: CustomColumnValue | CustomColumnValue[]
+  value: RosterColumnValue | RosterColumnValue[]
 };
 
 type SearchRosterBody = {
@@ -617,15 +537,6 @@ type SearchRosterBody = {
 
 type ReportDateQuery = {
   reportDate: string
-};
-
-type RosterFileRow = {
-  [key: string]: string
-};
-
-export type RosterEntryData = {
-  unit?: number,
-  [key: string]: CustomColumnValue | undefined
 };
 
 type AddCustomColumnBody = CustomColumnData & Required<Pick<CustomColumnData, 'displayName' | 'type'>>;

--- a/server/api/roster/roster.controller.ts
+++ b/server/api/roster/roster.controller.ts
@@ -8,7 +8,10 @@ import {
   OrderByCondition,
   SelectQueryBuilder,
 } from 'typeorm';
-import { assertRequestBody } from '../../util/api-utils';
+import {
+  assertRequestBody,
+  assertRequestParams,
+} from '../../util/api-utils';
 import {
   BadRequestError,
   NotFoundError,
@@ -359,7 +362,8 @@ class RosterController {
   }
 
   async updateRosterEntry(req: ApiRequest<OrgRosterParams, RosterEntryData>, res: Response) {
-    const entryId = parseInt(req.params.rosterId);
+    assertRequestParams(req, ['rosterId']);
+    const entryId = +req.params.rosterId;
 
     const entry = await getManager().transaction(async manager => {
       return editRosterEntry(req.appOrg!, req.appUserRole!, entryId, req.body, manager);

--- a/server/api/roster/roster.model.ts
+++ b/server/api/roster/roster.model.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
   Entity,
   Unique,
@@ -16,6 +17,16 @@ import { UserRole } from '../user/user-role.model';
 @Entity()
 @Unique(['edipi', 'unit'])
 export class Roster extends RosterEntity {
+
+  clone() {
+    const entry = new Roster();
+    entry.edipi = this.edipi;
+    entry.unit = this.unit;
+    entry.firstName = this.firstName;
+    entry.lastName = this.lastName;
+    entry.customColumns = _.cloneDeep(this.customColumns);
+    return entry;
+  }
 
   static getColumnSelect(column: RosterColumnInfo) {
     // Make sure custom columns are converted to appropriate types

--- a/server/api/roster/roster.types.ts
+++ b/server/api/roster/roster.types.ts
@@ -1,7 +1,7 @@
 import { CustomColumnConfig } from './custom-roster-column.model';
 
 export interface CustomColumns {
-  [columnName: string]: RosterColumnValue | undefined
+  [columnName: string]: RosterColumnValue
 }
 
 export type RosterColumnValue = string | boolean | number | null;

--- a/server/api/roster/roster.types.ts
+++ b/server/api/roster/roster.types.ts
@@ -1,10 +1,10 @@
 import { CustomColumnConfig } from './custom-roster-column.model';
 
 export interface CustomColumns {
-  [key: string]: CustomColumnValue
+  [columnName: string]: RosterColumnValue | undefined
 }
 
-export type CustomColumnValue = string | boolean | number | null;
+export type RosterColumnValue = string | boolean | number | null;
 
 export enum RosterColumnType {
   String = 'string',

--- a/server/api/unit/unit.model.ts
+++ b/server/api/unit/unit.model.ts
@@ -30,7 +30,7 @@ export class Unit extends BaseEntity {
   @Column({
     default: true,
   })
-  includeDefaultConfig: boolean;
+  includeDefaultConfig!: boolean;
 
   @Column('json', {
     nullable: false,

--- a/server/util/api-utils.ts
+++ b/server/util/api-utils.ts
@@ -25,6 +25,18 @@ export function assertRequestBody<TBody, TBodyKey extends keyof TBody>(
   return req.body;
 }
 
+export function assertRequestParams<TParams, TParamsKey extends keyof TParams>(
+  req: ApiRequest<TParams, unknown, unknown>,
+  requiredKeys: Array<TParamsKey>,
+) {
+  const missingKeys = getMissingKeys(req.params, requiredKeys);
+  if (missingKeys.length) {
+    throw new BadRequestError(`Missing required request url params: ${missingKeys.join(', ')}`);
+  }
+
+  return req.params;
+}
+
 function getMissingKeys<T, K extends keyof T>(obj: T, keys: Array<K>) {
   return keys.filter(key => obj[key] === undefined);
 }

--- a/server/util/api-utils.ts
+++ b/server/util/api-utils.ts
@@ -1,9 +1,9 @@
 import { ApiRequest } from '../api';
 import { BadRequestError } from './error-types';
 
-export function assertRequestQuery<TQuery extends object>(
+export function assertRequestQuery<TQuery, TQueryKey extends keyof TQuery>(
   req: ApiRequest<unknown, unknown, TQuery>,
-  requiredKeys: Array<keyof TQuery>,
+  requiredKeys: Array<TQueryKey>,
 ) {
   const missingKeys = getMissingKeys(req.query, requiredKeys);
   if (missingKeys.length) {
@@ -13,9 +13,9 @@ export function assertRequestQuery<TQuery extends object>(
   return req.query;
 }
 
-export function assertRequestBody<TBody extends object>(
+export function assertRequestBody<TBody, TBodyKey extends keyof TBody>(
   req: ApiRequest<unknown, TBody, unknown>,
-  requiredKeys: Array<keyof TBody>,
+  requiredKeys: Array<TBodyKey>,
 ) {
   const missingKeys = getMissingKeys(req.body, requiredKeys);
   if (missingKeys.length) {
@@ -25,6 +25,6 @@ export function assertRequestBody<TBody extends object>(
   return req.body;
 }
 
-function getMissingKeys<T extends object>(obj: T, keys: Array<keyof T>) {
+function getMissingKeys<T, K extends keyof T>(obj: T, keys: Array<K>) {
   return keys.filter(key => obj[key] === undefined);
 }

--- a/server/util/error-types.ts
+++ b/server/util/error-types.ts
@@ -68,6 +68,22 @@ export class InternalServerError extends RequestError {
   }
 }
 
+export class RequiredColumnError extends RequestError {
+  constructor(columnName: string, showErrorPage = false) {
+    const message = `Required column '${columnName}' cannot be empty, null, or undefined.`;
+    super(message, 'BadRequest', 400, showErrorPage);
+    Error.captureStackTrace(this, RequiredColumnError);
+  }
+}
+
+export class DateParseError extends RequestError {
+  constructor(date: any, showErrorPage = false) {
+    const message = `Unable to parse date '${date}'. Valid dates are ISO formatted date strings and UNIX timestamps.`;
+    super(message, 'BadRequest', 400, showErrorPage);
+    Error.captureStackTrace(this, DateParseError);
+  }
+}
+
 export type RequestErrorType = (
   'BadRequest' |
   'Unauthorized' |

--- a/server/util/error-types.ts
+++ b/server/util/error-types.ts
@@ -1,3 +1,5 @@
+import { OrphanedRecord } from '../api/orphaned-record/orphaned-record.model';
+
 export class RequestError extends Error {
   type: RequestErrorType;
   statusCode: number;
@@ -81,6 +83,14 @@ export class DateParseError extends RequestError {
     const message = `Unable to parse date '${date}'. Valid dates are ISO formatted date strings and UNIX timestamps.`;
     super(message, 'BadRequest', 400, showErrorPage);
     Error.captureStackTrace(this, DateParseError);
+  }
+}
+
+export class OrphanedRecordsNotFoundError extends RequestError {
+  constructor(compositeId: OrphanedRecord['compositeId'], showErrorPage = false) {
+    const message = `Unable to locate orphaned record with id: ${compositeId}`;
+    super(message, 'NotFound', 404, showErrorPage);
+    Error.captureStackTrace(this, OrphanedRecordsNotFoundError);
   }
 }
 

--- a/server/util/orphaned-records-utils.ts
+++ b/server/util/orphaned-records-utils.ts
@@ -1,0 +1,55 @@
+import { OrphanedRecordAction } from '../api/orphaned-record/orphaned-record-action.model';
+import { OrphanedRecord } from '../api/orphaned-record/orphaned-record.model';
+import { RosterHistory } from '../api/roster/roster-history.model';
+
+export function buildVisibleOrphanedRecordResultsQuery(userEdipi: string, orgId: number) {
+  const params = {
+    now: new Date(),
+    orgId,
+    userEdipi,
+  };
+
+  const rosterEntries = RosterHistory.createQueryBuilder('rh')
+    .leftJoin('rh.unit', 'u')
+    .select('rh.id', 'id')
+    .addSelect('rh.edipi', 'edipi')
+    .addSelect('rh.timestamp', 'timestamp')
+    .addSelect('rh.change_type', 'change_type')
+    .addSelect('rh.unit_id', 'unit_id')
+    .where('u.org_id = :orgId', { orgId })
+    .distinctOn(['rh.unit_id', 'rh.edipi'])
+    .orderBy('rh.unit_id')
+    .addOrderBy('rh.edipi', 'DESC')
+    .addOrderBy('rh.timestamp', 'DESC')
+    .addOrderBy('rh.change_type', 'DESC');
+
+  return OrphanedRecord.createQueryBuilder('orphan')
+    .leftJoin(OrphanedRecordAction, 'action', `action.id=orphan.composite_id AND (action.expires_on > :now OR action.expires_on IS NULL) AND (action.type='claim' OR (action.user_edipi=:userEdipi AND action.type='ignore'))`, params)
+    .leftJoin(`(${rosterEntries.getQuery()})`, 'roster', 'orphan.edipi = roster.edipi')
+    .where('orphan.org_id=:orgId', params)
+    .andWhere('orphan.deleted_on IS NULL')
+    .andWhere(`(roster.change_type IS NULL OR roster.change_type <> 'deleted')`)
+    .andWhere(`(action.type IS NULL OR (action.type='claim' AND action.user_edipi=:userEdipi))`, params)
+    .select('orphan.edipi', 'edipi')
+    .addSelect('orphan.unit', 'unit')
+    .addSelect('orphan.phone', 'phone')
+    .addSelect('action.type', 'action')
+    .addSelect('action.expires_on', 'claimedUntil')
+    .addSelect('MAX(orphan.timestamp)', 'latestReportDate')
+    .addSelect('MIN(orphan.timestamp)', 'earliestReportDate')
+    .addSelect('COUNT(*)::INTEGER', 'count')
+    .addSelect('orphan.composite_id', 'id')
+    .addSelect('roster.unit_id', 'unitId')
+    .addSelect('roster.id', 'rosterHistoryId')
+    .orderBy('orphan.count', 'DESC')
+    .addOrderBy('orphan.unit', 'ASC')
+    .addOrderBy('orphan.edipi', 'ASC')
+    .groupBy('orphan.composite_id')
+    .addGroupBy('orphan.edipi')
+    .addGroupBy('orphan.unit')
+    .addGroupBy('orphan.phone')
+    .addGroupBy('action.type')
+    .addGroupBy('action.expires_on')
+    .addGroupBy('roster.unit_id')
+    .addGroupBy('roster.id');
+}

--- a/src/components/pages/roster-page/roster-page.tsx
+++ b/src/components/pages/roster-page/roster-page.tsx
@@ -57,6 +57,7 @@ import {
   ApiRosterEntry,
   ApiRosterPaginated,
   ApiOrphanedRecord,
+  ApiRosterEntryData,
 } from '../../../models/api-response';
 import {
   EditRosterEntryDialog,
@@ -493,8 +494,8 @@ export const RosterPage = () => {
         edipi: row.edipi,
         unit: units.find(unit => unit.name === row.unit)?.id,
       },
-      onSave: async (body: any) => {
-        return axios.put(`api/orphaned-record/${orgId}/${row.id}/resolve`, body);
+      onSave: async (body: ApiRosterEntryData) => {
+        return axios.put(`api/orphaned-record/${orgId}/${row.id}/resolve-with-add`, body);
       },
       onClose: async () => {
         setEditRosterEntryDialogProps({ open: false });
@@ -518,9 +519,8 @@ export const RosterPage = () => {
       rosterColumnInfos,
       rosterEntry,
       orphanedRecord: row,
-      onSave: async (body: any) => {
-        await axios.put(`api/roster/${orgId}/${rosterEntry.id}`, body);
-        await axios.put(`api/orphaned-record/${orgId}/${row.id}/resolve`, body);
+      onSave: async (body: ApiRosterEntry) => {
+        return axios.put(`api/orphaned-record/${orgId}/${row.id}/resolve-with-edit`, body);
       },
       onClose: async () => {
         setEditRosterEntryDialogProps({ open: false });

--- a/src/models/api-response.ts
+++ b/src/models/api-response.ts
@@ -1,3 +1,4 @@
+import { RosterColumnValue } from '../../server/api/roster/roster.types';
 import { DaysOfTheWeek } from '../utility/days';
 
 export interface ApiPaginated<TData> {
@@ -146,11 +147,20 @@ export interface ApiRosterColumnInfo extends ColumnInfo {
   config: ApiRosterCustomColumnConfig,
 }
 
-export interface ApiRosterEntry {
-  id: number,
+export type ApiCustomColumns = {
+  [columnName: string]: RosterColumnValue | undefined
+};
+
+export type ApiRosterEntryData = {
+  edipi: string,
   unit: number,
-  [key: string]: string | boolean | number | null,
-}
+  firstName?: string,
+  lastName?: string,
+} & ApiCustomColumns;
+
+export type ApiRosterEntry = ApiRosterEntryData & {
+  id: number,
+};
 
 export interface ApiOrphanedRecord {
   id: string;


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200247812176180

My apologies for so much refactoring. Once I started with the resolve endpoints I couldn't help but clean up the roster column stuff, which had been bugging me for a long time. The roster column functionality was feeling very confusing and error prone, so I thought it was worth a little extra time.

For orphaned record resolution, I figured it was best to split add and edit into separate endpoints to avoid making things too murky with lots of code paths. And instead of having to call two endpoints to edit an orphaned record and resolve it, it's all contained within one `/resolve-with-edit` endpoint now, so that the client doesn't have to worry about the implementation details and we can rollback if something goes wrong. It's not really a true rollback, since the roster history will still be updated, but it will at least return your active roster to the state it was in. We probably need to think about moving the roster history updates out of a trigger, so that we can have more control over it. I think having that in a trigger is just making things more complicated.

As far as the roster column refactoring, I tried to unify roster column functionality as much as possible, so that you always call `rosterEntry.setColumnValue()` to update any column data, and `rosterEntry.getColumnValue()` to get any column data. There were several utility functions scattered around before doing that in a variety of ways, which got very confusing. Those should all be gone now, and all of that should happen within `roster-entity.ts`.

I also added some seeding of mock orphaned records, so that we can catch any UI issues with that stuff before it reaches production.