### PR TITLE
Csv error handling

### DIFF
--- a/seed-dev.sh
+++ b/seed-dev.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source ./utils.sh
+
 export NODE_ENV=development
 export SQL_HOST=${SQL_HOST:=localhost}
 export SQL_PORT=${SQL_PORT:=5432}
@@ -8,29 +10,21 @@ export SQL_PASSWORD=${SQL_PASSWORD:=postgres}
 export SQL_DATABASE=${SQL_DATABASE:=dds}
 export PGPASSWORD=$SQL_PASSWORD
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-
 read -r -p "Are you sure? This will delete existing data in your local '$SQL_DATABASE' database. [y/N] " response
 case "$response" in
-[yY][eE][sS] | [yY])
-  if [ "$(psql -tAc "SELECT 1 FROM pg_database WHERE datname='$SQL_DATABASE'" -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER")" = '1' ]; then
-    dropdb -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER" "$SQL_DATABASE" || {
-      echo "Failed to drop '$SQL_DATABASE' database. You may still have an open connection."
-      exit
-    }
-    echo "Dropped existing '$SQL_DATABASE' database"
-  fi
+  [yY][eE][sS] | [yY])
+    if [[ "$(database_exists)" ]]; then
+      drop_database
+    fi
 
-  createdb -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER" "$SQL_DATABASE" || {
-    echo "Failed to create '$SQL_DATABASE' database."
-    exit
-  }
-  echo "Created '$SQL_DATABASE' database"
+    if ! [[ "$(database_exists)" ]]; then
+      create_database
+    fi
 
-  ./migration-run.sh
-  npx ts-node --project "$DIR/server/tsconfig.json" "$DIR/server/sqldb/seed-dev.ts"
-  ;;
-*)
-  echo "Aborted"
-  ;;
+    ./migration-run.sh
+    npx ts-node --project "$(dir)/server/tsconfig.json" "$(dir)/server/sqldb/seed-dev.ts"
+    ;;
+  *)
+    echo "Aborted"
+    ;;
 esac

--- a/server/api/export/export.controller.ts
+++ b/server/api/export/export.controller.ts
@@ -16,7 +16,7 @@ import {
   OrgParam,
   PaginatedQuery,
 } from '../index';
-import { RosterEntryData } from '../roster/roster-entity';
+import { RosterEntryData } from '../roster/roster.types';
 import { Roster } from '../roster/roster.model';
 import { Unit } from '../unit/unit.model';
 

--- a/server/api/orphaned-record/orphaned-record.controller.ts
+++ b/server/api/orphaned-record/orphaned-record.controller.ts
@@ -26,11 +26,9 @@ import {
   PaginatedQuery,
 } from '../index';
 import { Org } from '../org/org.model';
-import {
-  RosterEntity,
-  RosterEntryData,
-} from '../roster/roster-entity';
+import { RosterEntity } from '../roster/roster-entity';
 import { Roster } from '../roster/roster.model';
+import { RosterEntryData } from '../roster/roster.types';
 import {
   ActionType,
   OrphanedRecordAction,

--- a/server/api/roster/custom-roster-column.model.ts
+++ b/server/api/roster/custom-roster-column.model.ts
@@ -10,8 +10,10 @@ import {
 } from 'typeorm';
 import _ from 'lodash';
 import { Org } from '../org/org.model';
-import { baseRosterColumns } from './roster-entity';
-import { RosterColumnType } from './roster.types';
+import {
+  baseRosterColumns,
+  RosterColumnType,
+} from './roster.types';
 
 @Entity()
 export class CustomRosterColumn extends BaseEntity {

--- a/server/api/roster/roster-entity.ts
+++ b/server/api/roster/roster-entity.ts
@@ -95,6 +95,49 @@ export abstract class RosterEntity extends BaseEntity {
     return Reflect.get(this, column.name);
   }
 
+  setColumnValue(column: RosterColumnInfo, value: RosterColumnValue | undefined) {
+    const validValue = this.validateColumnValue(column, value);
+    if (validValue === undefined) {
+      return;
+    }
+
+    // Set the value.
+    if (column.custom) {
+      if (!this.customColumns) {
+        this.customColumns = {};
+      }
+      this.customColumns[column.name] = validValue;
+    } else {
+      Reflect.set(this, column.name, validValue);
+    }
+  }
+
+  setColumnValueFromData(column: RosterColumnInfo, data: RosterEntryData) {
+    const expectedType = columnTypeToEntryDataType(column.type);
+
+    // Get the column value from the data.
+    let value: RosterColumnValue | undefined;
+    if (column.required) {
+      value = getRequiredValue(column.name, data, expectedType);
+    } else {
+      value = getOptionalValue(column.name, data, expectedType);
+    }
+
+    this.setColumnValue(column, value);
+  }
+
+  setColumnValueFromFileRow(column: RosterColumnInfo, row: RosterFileRow) {
+    // Get the string value from the row data.
+    let value: string | null | undefined;
+    if (column.required) {
+      value = getRequiredValue(column.displayName, row, 'string');
+    } else {
+      value = getOptionalValue(column.displayName, row, 'string');
+    }
+
+    this.setColumnValue(column, value);
+  }
+
   validateColumnValue(column: RosterColumnInfo, value: RosterColumnValue | undefined): RosterColumnValue | undefined {
     if (typeof value === 'string') {
       const maxLength = getColumnMaxLength(this.getEntityTarget(), column.name);
@@ -152,49 +195,6 @@ export abstract class RosterEntity extends BaseEntity {
     }
 
     return value;
-  }
-
-  setColumnValue(column: RosterColumnInfo, value: RosterColumnValue | undefined) {
-    const validValue = this.validateColumnValue(column, value);
-    if (validValue === undefined) {
-      return;
-    }
-
-    // Set the value.
-    if (column.custom) {
-      if (!this.customColumns) {
-        this.customColumns = {};
-      }
-      this.customColumns[column.name] = validValue;
-    } else {
-      Reflect.set(this, column.name, validValue);
-    }
-  }
-
-  setColumnValueFromData(column: RosterColumnInfo, data: RosterEntryData) {
-    const expectedType = columnTypeToEntryDataType(column.type);
-
-    // Get the column value from the data.
-    let value: RosterColumnValue | undefined;
-    if (column.required) {
-      value = getRequiredValue(column.name, data, expectedType);
-    } else {
-      value = getOptionalValue(column.name, data, expectedType);
-    }
-
-    this.setColumnValue(column, value);
-  }
-
-  setColumnValueFromFileRow(column: RosterColumnInfo, row: RosterFileRow) {
-    // Get the string value from the row data.
-    let value: string | null | undefined;
-    if (column.required) {
-      value = getRequiredValue(column.displayName, row, 'string');
-    } else {
-      value = getOptionalValue(column.displayName, row, 'string');
-    }
-
-    this.setColumnValue(column, value);
   }
 
 }

--- a/server/api/roster/roster-history.model.ts
+++ b/server/api/roster/roster-history.model.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  EntityTarget,
 } from 'typeorm';
 import { RosterEntity } from './roster-entity';
 import { timestampColumnTransformer } from '../../util/util';
@@ -27,5 +28,9 @@ export class RosterHistory extends RosterEntity {
     default: ChangeType.Changed,
   })
   changeType!: ChangeType;
+
+  getEntityTarget(): EntityTarget<any> {
+    return RosterHistory;
+  }
 
 }

--- a/server/api/roster/roster.controller.spec.ts
+++ b/server/api/roster/roster.controller.spec.ts
@@ -22,7 +22,6 @@ import {
 } from '../user/user.model.mock';
 import { CustomRosterColumn } from './custom-roster-column.model';
 import { seedCustomRosterColumn } from './custom-roster-column.model.mock';
-import { baseRosterColumns } from './roster-entity';
 import {
   ChangeType,
   RosterHistory,
@@ -33,7 +32,10 @@ import {
   seedRosterEntries,
   seedRosterEntry,
 } from './roster.model.mock';
-import { RosterColumnType } from './roster.types';
+import {
+  baseRosterColumns,
+  RosterColumnType,
+} from './roster.types';
 
 describe(`Roster Controller`, () => {
 

--- a/server/api/roster/roster.model.mock.ts
+++ b/server/api/roster/roster.model.mock.ts
@@ -1,12 +1,15 @@
 import { json2csvAsync } from 'json-2-csv';
-import { uniqueString } from '../../util/test-utils/unique';
+import {
+  uniqueEdipi,
+  uniqueString,
+} from '../../util/test-utils/unique';
 import { Unit } from '../unit/unit.model';
 import { Roster } from './roster.model';
 
 export function mockRosterEntry(unit: Unit) {
   return Roster.create({
     unit,
-    edipi: uniqueString(),
+    edipi: uniqueEdipi(),
     firstName: uniqueString(),
     lastName: uniqueString(),
     customColumns: {
@@ -42,10 +45,10 @@ export function mockRosterUploadCsv(args: {
   for (let i = 0; i < rosterCount; i++) {
     const entry = mockRosterEntry(unit);
     const entryData = {
-      unit: entry.unit.name,
-      edipi: entry.edipi,
-      firstName: entry.firstName,
-      lastName: entry.lastName,
+      Unit: entry.unit.name,
+      'DoD ID': entry.edipi,
+      'First Name': entry.firstName,
+      'Last Name': entry.lastName,
     } as any;
 
     for (const key of Object.keys(entry.customColumns)) {

--- a/server/api/roster/roster.model.ts
+++ b/server/api/roster/roster.model.ts
@@ -1,22 +1,28 @@
 import _ from 'lodash';
 import {
   Entity,
+  EntityTarget,
   Unique,
 } from 'typeorm';
 import { snakeCase } from 'typeorm/util/StringUtils';
 import {
+  baseRosterColumns,
   RosterColumnInfo,
   RosterColumnType,
 } from './roster.types';
 import { Org } from '../org/org.model';
 import { Role } from '../role/role.model';
 import { CustomRosterColumn } from './custom-roster-column.model';
-import { baseRosterColumns, RosterEntity } from './roster-entity';
+import { RosterEntity } from './roster-entity';
 import { UserRole } from '../user/user-role.model';
 
 @Entity()
 @Unique(['edipi', 'unit'])
 export class Roster extends RosterEntity {
+
+  getEntityTarget(): EntityTarget<any> {
+    return Roster;
+  }
 
   clone() {
     const entry = new Roster();

--- a/server/api/roster/roster.types.ts
+++ b/server/api/roster/roster.types.ts
@@ -1,4 +1,5 @@
 import { CustomColumnConfig } from './custom-roster-column.model';
+import { RosterEntity } from './roster-entity';
 
 export interface CustomColumns {
   [columnName: string]: RosterColumnValue
@@ -27,3 +28,58 @@ export interface RosterColumnInfo {
   config?: CustomColumnConfig
 }
 
+export interface BaseRosterColumnInfo extends RosterColumnInfo {
+  name: 'edipi' | 'firstName' | 'lastName'
+}
+
+export const baseRosterColumnLookup: Readonly<{
+  [K in BaseRosterColumnInfo['name']]: Readonly<BaseRosterColumnInfo>
+}> = {
+  edipi: {
+    name: 'edipi',
+    displayName: 'DoD ID',
+    type: RosterColumnType.String,
+    pii: true,
+    phi: false,
+    custom: false,
+    required: true,
+    updatable: false,
+  },
+  firstName: {
+    name: 'firstName',
+    displayName: 'First Name',
+    type: RosterColumnType.String,
+    pii: true,
+    phi: false,
+    custom: false,
+    required: true,
+    updatable: true,
+  },
+  lastName: {
+    name: 'lastName',
+    displayName: 'Last Name',
+    type: RosterColumnType.String,
+    pii: true,
+    phi: false,
+    custom: false,
+    required: true,
+    updatable: true,
+  },
+};
+
+export const baseRosterColumns: Readonly<Readonly<BaseRosterColumnInfo>>[] = Object.values(baseRosterColumnLookup);
+
+export const edipiColumnDisplayName = baseRosterColumnLookup.edipi.displayName;
+export const unitColumnDisplayName = 'Unit';
+
+export type RosterEntryData = {
+  edipi: RosterEntity['edipi'],
+  unit: number,
+  firstName?: RosterEntity['firstName'],
+  lastName?: RosterEntity['lastName'],
+} & CustomColumns;
+
+export type RosterFileRow = {
+  Unit: string
+  [columnName: string]: string
+};

--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source ../utils.sh
+
 LOG_LEVEL="test"
 CLEAN=false
 
@@ -27,23 +29,15 @@ export PGPASSWORD=$SQL_PASSWORD
 export TYPEORM_CACHE=false
 
 # If the clean flag is passed in, drop the database to start fresh.
-if [ "$CLEAN" == true ]; then
-  if psql -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER" -lqt | cut -d \| -f 1 | grep -qw "$SQL_DATABASE"; then
-    echo -n "Dropping '$SQL_DATABASE' database... "
-    dropdb -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER" "$SQL_DATABASE"
-    echo "success!"
+if $CLEAN; then
+  if [[ "$(database_exists)" ]]; then
+    drop_database
   fi
 fi
 
 # Create test database if it doesn't exist.
-if ! psql -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER" -lqt | cut -d \| -f 1 | grep -qw "$SQL_DATABASE"; then
-  echo -n "Creating '$SQL_DATABASE' database... "
-  createdb -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER" "$SQL_DATABASE" || {
-    echo "failed to create '$SQL_DATABASE' database. Aborting..."
-    exit
-  }
-  echo "success!"
-
+if ! [[ "$(database_exists)" ]]; then
+  create_database
   ../migration-run.sh
 fi
 

--- a/server/util/api-utils.ts
+++ b/server/util/api-utils.ts
@@ -1,5 +1,6 @@
 import { ApiRequest } from '../api';
 import { BadRequestError } from './error-types';
+import { getMissingKeys } from './util';
 
 export function assertRequestQuery<TQuery, TQueryKey extends keyof TQuery>(
   req: ApiRequest<unknown, unknown, TQuery>,
@@ -35,8 +36,4 @@ export function assertRequestParams<TParams, TParamsKey extends keyof TParams>(
   }
 
   return req.params;
-}
-
-function getMissingKeys<T, K extends keyof T>(obj: T, keys: Array<K>) {
-  return keys.filter(key => obj[key] === undefined);
 }

--- a/server/util/roster-utils.ts
+++ b/server/util/roster-utils.ts
@@ -1,12 +1,9 @@
 import { EntityManager } from 'typeorm';
 import { Org } from '../api/org/org.model';
 import { Role } from '../api/role/role.model';
-import {
-  RosterEntity,
-  RosterEntryData,
-} from '../api/roster/roster-entity';
 import { RosterHistory } from '../api/roster/roster-history.model';
 import { Roster } from '../api/roster/roster.model';
+import { RosterEntryData } from '../api/roster/roster.types';
 import { Unit } from '../api/unit/unit.model';
 import { UserRole } from '../api/user/user-role.model';
 import {
@@ -55,7 +52,7 @@ export async function addRosterEntry(org: Org, role: Role, entryData: RosterEntr
   return manager.save(entry);
 }
 
-export async function editRosterEntry(org: Org, userRole: UserRole, entryId: RosterEntity['id'], entryData: RosterEntryData, manager: EntityManager) {
+export async function editRosterEntry(org: Org, userRole: UserRole, entryId: number, entryData: RosterEntryData, manager: EntityManager) {
   const { unit: unitId } = entryData;
 
   let entry = await Roster.findOne({

--- a/server/util/typeorm-utils.ts
+++ b/server/util/typeorm-utils.ts
@@ -1,0 +1,34 @@
+import {
+  EntityTarget,
+  getConnection,
+} from 'typeorm';
+
+export function getDatabaseErrorMessage(err: DatabaseError) {
+  switch (err.code) {
+    case '22001': {
+      const maxLengthMatch = err.message.match(/\((\d.)\)/);
+      const maxLength = parseInt(maxLengthMatch?.[1] ?? '');
+      if (!Number.isNaN(maxLength)) {
+        return `Value exceeds max length of ${maxLength} characters.`;
+      }
+
+      return 'Value is too long.';
+    }
+    default:
+      return err.message;
+  }
+}
+
+export function getColumnMaxLength(entityType: EntityTarget<any>, columnName: string) {
+  const entityMetadata = getConnection().getMetadata(entityType);
+  const columnMetadata = entityMetadata.columns.find(x => x.propertyName === columnName);
+
+  // Metadata 'length' value here will be what was set on the @Column() decorator.
+  const maxLength = parseInt(columnMetadata?.length ?? '');
+
+  return Number.isNaN(maxLength) ? undefined : maxLength;
+}
+
+interface DatabaseError extends Error {
+  code: string
+}

--- a/server/util/typeorm-utils.ts
+++ b/server/util/typeorm-utils.ts
@@ -5,7 +5,8 @@ import {
 
 export function getDatabaseErrorMessage(err: DatabaseError) {
   switch (err.code) {
-    case '22001': {
+    case DatabaseErrorCode.ValueExceedsMaxLength: {
+      // The error message coming back should have the max length in parentheses.
       const maxLengthMatch = err.message.match(/\((\d.)\)/);
       const maxLength = parseInt(maxLengthMatch?.[1] ?? '');
       if (!Number.isNaN(maxLength)) {
@@ -32,4 +33,8 @@ export function getColumnMaxLength(entityType: EntityTarget<any>, columnName: st
 
 interface DatabaseError extends Error {
   code: string
+}
+
+enum DatabaseErrorCode {
+  ValueExceedsMaxLength = '22001',
 }

--- a/server/util/typeorm-utils.ts
+++ b/server/util/typeorm-utils.ts
@@ -19,13 +19,14 @@ export function getDatabaseErrorMessage(err: DatabaseError) {
   }
 }
 
-export function getColumnMaxLength(entityType: EntityTarget<any>, columnName: string) {
+export function getColumnMetadata(entityType: EntityTarget<any>, columnName: string) {
   const entityMetadata = getConnection().getMetadata(entityType);
-  const columnMetadata = entityMetadata.columns.find(x => x.propertyName === columnName);
+  return entityMetadata.columns.find(x => x.propertyName === columnName);
+}
 
-  // Metadata 'length' value here will be what was set on the @Column() decorator.
+export function getColumnMaxLength(entityType: EntityTarget<any>, columnName: string) {
+  const columnMetadata = getColumnMetadata(entityType, columnName);
   const maxLength = parseInt(columnMetadata?.length ?? '');
-
   return Number.isNaN(maxLength) ? undefined : maxLength;
 }
 

--- a/server/util/util.ts
+++ b/server/util/util.ts
@@ -180,3 +180,7 @@ export function getMomentDateFormat(interval: TimeInterval) {
       throw new Error(`Unsupported interval '${interval}'`);
   }
 }
+
+export function getMissingKeys<T, K extends keyof T>(obj: T, keys: Array<K>) {
+  return keys.filter(key => obj[key] === undefined);
+}

--- a/src/actions/roster.actions.ts
+++ b/src/actions/roster.actions.ts
@@ -1,18 +1,10 @@
 import { Dispatch } from 'redux';
-import { AppState } from '../store';
 import { ApiRosterColumnInfo } from '../models/api-response';
 import { RosterClient } from '../client';
-import { formatMessage } from '../utility/errors';
 
 export namespace Roster {
 
   export namespace Actions {
-
-    export class Upload {
-      static type = 'ROSTER_UPLOAD';
-      type = Upload.type;
-    }
-
 
     export class FetchColumns {
       static type = 'FETCH_ROSTER_COLUMNS';
@@ -52,34 +44,6 @@ export namespace Roster {
       }) { }
     }
   }
-
-  export const upload = (file: File, onComplete: (response: RosterClient.UploadResponse, message?: string) => void) => async (dispatch: Dispatch<Actions.Upload>, getState: () => AppState) => {
-    console.log('uploading file...');
-    console.log('file', file);
-
-    const appState = getState();
-    const orgId = appState.user.activeRole?.role.org?.id;
-
-    if (!appState.user.activeRole || !orgId) {
-      console.log('User has no active role for orgId, cannot upload roster.');
-      return;
-    }
-
-    let response: RosterClient.UploadResponse | undefined;
-    let message: string | undefined;
-
-    try {
-      response = await RosterClient.upload(orgId, file);
-    } catch (error) {
-      message = formatMessage(error, 'Failed to upload roster');
-    } finally {
-      onComplete(response ?? { count: -1, errors: undefined }, message);
-    }
-
-    console.log('upload complete!');
-
-    dispatch(new Actions.Upload());
-  };
 
   export const fetchColumns = (orgId: number) => async (dispatch: Dispatch) => {
     dispatch(new Actions.FetchColumns());

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -12,6 +12,7 @@ import {
   ApiReportSchema,
   ApiRole,
   ApiRosterColumnInfo,
+  ApiRosterUploadInfo,
   ApiUnit,
   ApiUser,
   ApiWorkspace,
@@ -123,36 +124,17 @@ export namespace OrphanedRecordClient {
 }
 
 export namespace RosterClient {
-  export type UploadError = {
-    error: string,
-    edipi?: string,
-    line?: number,
-    column?: string,
-  };
-  export interface UploadResponse {
-    count: number
-    errors: UploadError[] | undefined
-  }
   export const fetchColumns = (orgId: number): Promise<ApiRosterColumnInfo[]> => {
     return client.get(`roster/${orgId}/column`);
   };
-  export const upload = async (orgId: number, file: File): Promise<UploadResponse> => {
+  export const upload = async (orgId: number, file: File): Promise<ApiRosterUploadInfo> => {
     const formData = new FormData();
     formData.append('roster_csv', file);
-    let response: UploadResponse | undefined;
-    try {
-      response = await client.post(`roster/${orgId}/bulk`, formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      });
-    } catch (error) {
-      if (error.data?.errors?.length) {
-        return error.data;
-      }
-      throw error;
-    }
-    return response ?? { count: -1, errors: [] };
+    return client.post(`roster/${orgId}/bulk`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
   };
   export const deleteAll = (orgId: number) => {
     return client.delete(`roster/${orgId}/bulk`);

--- a/src/components/error-boundary/error-boundary.tsx
+++ b/src/components/error-boundary/error-boundary.tsx
@@ -1,7 +1,7 @@
 import React, { ErrorInfo } from 'react';
 import { Snackbar, SnackbarOrigin } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
-import { formatMessage } from '../../utility/errors';
+import { formatErrorMessage } from '../../utility/errors';
 
 
 export interface ErrorBoundaryState {
@@ -24,7 +24,7 @@ export class ErrorBoundary extends React.Component<{}, ErrorBoundaryState> {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    const message = error.message ?? formatMessage(error, '');
+    const message = error.message ?? formatErrorMessage(error, '');
 
     this.setState({
       error,

--- a/src/components/pages/data-export-page/data-export-page.tsx
+++ b/src/components/pages/data-export-page/data-export-page.tsx
@@ -17,7 +17,7 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Modal } from '../../../actions/modal.actions';
-import { ApiError } from '../../../models/api-response';
+import { ApiErrorResponseData } from '../../../models/api-response';
 import { UserSelector } from '../../../selectors/user.selector';
 import { downloadFile } from '../../../utility/download';
 import { getLineCount } from '../../../utility/string-utils';
@@ -58,7 +58,7 @@ export const DataExportPage = () => {
     if (response.status !== 200) {
       let message: string | undefined;
       try {
-        const error = await response.json() as ApiError;
+        const error = await response.json() as ApiErrorResponseData;
         message = error.errors[0].message;
       } finally {
         if (!message) {
@@ -99,7 +99,7 @@ export const DataExportPage = () => {
     try {
       await runExport();
     } catch (err) {
-      dispatch(Modal.alert('Export Failed', err.message));
+      dispatch(Modal.alert('Export Failed', err.message)).then();
     } finally {
       setIsExportLoading(false);
     }

--- a/src/components/pages/edit-spaces-page/edit-space-dialog.tsx
+++ b/src/components/pages/edit-spaces-page/edit-space-dialog.tsx
@@ -11,7 +11,7 @@ import axios from 'axios';
 import CheckIcon from '@material-ui/icons/Check';
 import useStyles from './edit-space-dialog.styles';
 import { ApiWorkspace, ApiWorkspaceTemplate } from '../../../models/api-response';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 
 export interface EditWorkspaceDialogProps {
   open: boolean,
@@ -89,7 +89,7 @@ export const EditSpaceDialog = (props: EditWorkspaceDialogProps) => {
       }
     } catch (error) {
       if (onError) {
-        onError(formatMessage(error));
+        onError(formatErrorMessage(error));
       }
       setFormDisabled(false);
       return;

--- a/src/components/pages/edit-spaces-page/edit-spaces-page.tsx
+++ b/src/components/pages/edit-spaces-page/edit-spaces-page.tsx
@@ -21,7 +21,7 @@ import { ApiWorkspace, ApiWorkspaceTemplate } from '../../../models/api-response
 import { EditSpaceDialog, EditWorkspaceDialogProps } from './edit-space-dialog';
 import { ButtonSet } from '../../buttons/button-set';
 import { Modal } from '../../../actions/modal.actions';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 import { UserSelector } from '../../../selectors/user.selector';
 import { EditSpacesPageHelp } from './edit-spaces-page-help';
 
@@ -96,7 +96,7 @@ export const EditSpacesPage = () => {
     try {
       await axios.delete(`api/workspace/${orgId}/${workspaceToDelete.id}`);
     } catch (error) {
-      dispatch(Modal.alert('Delete Space', formatMessage(error, 'Unable to delete space'))).then();
+      dispatch(Modal.alert('Delete Space', formatErrorMessage(error, 'Unable to delete space'))).then();
     }
     setWorkspaceToDelete(null);
     await initializeTable();

--- a/src/components/pages/muster-page/muster-page.tsx
+++ b/src/components/pages/muster-page/muster-page.tsx
@@ -57,7 +57,7 @@ import { UnitSelector } from '../../../selectors/unit.selector';
 import { Unit } from '../../../actions/unit.actions';
 import { DataExportIcon } from '../../icons/data-export-icon';
 import { Modal } from '../../../actions/modal.actions';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 import { UserSelector } from '../../../selectors/user.selector';
 
 interface TimeRange {
@@ -158,7 +158,7 @@ export const MusterPage = () => {
   }, [orgId, dispatch]);
 
   const showErrorDialog = useCallback((title: string, error: Error) => {
-    dispatch(Modal.alert(`Error: ${title}`, formatMessage(error))).then();
+    dispatch(Modal.alert(`Error: ${title}`, formatErrorMessage(error))).then();
   }, [dispatch]);
 
   const reloadTable = useCallback(async () => {
@@ -327,7 +327,7 @@ export const MusterPage = () => {
       const filename = `${_.kebabCase(orgName)}_${unitId}_muster-noncompliance_${startDate}_to_${endDate}`;
       downloadFile(response.data, filename, 'csv');
     } catch (error) {
-      dispatch(Modal.alert('Export to CSV', formatMessage(error, 'Unable to export'))).then();
+      dispatch(Modal.alert('Export to CSV', formatErrorMessage(error, 'Unable to export'))).then();
     } finally {
       setExportLoading(false);
     }

--- a/src/components/pages/role-management-page/edit-role-dialog.tsx
+++ b/src/components/pages/role-management-page/edit-role-dialog.tsx
@@ -32,7 +32,7 @@ import { EditableBooleanTable } from '../../tables/editable-boolean-table';
 import { RosterSelector } from '../../../selectors/roster.selector';
 import { NotificationSelector } from '../../../selectors/notification.selector';
 import { WorkspaceSelector } from '../../../selectors/workspace.selector';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 
 export interface EditRoleDialogProps {
   open: boolean,
@@ -166,7 +166,7 @@ export const EditRoleDialog = (props: EditRoleDialogProps) => {
       }
     } catch (error) {
       if (onError) {
-        onError(formatMessage(error));
+        onError(formatErrorMessage(error));
       }
       setFormDisabled(false);
       return;

--- a/src/components/pages/role-management-page/role-management-page.tsx
+++ b/src/components/pages/role-management-page/role-management-page.tsx
@@ -25,7 +25,7 @@ import { Role } from '../../../actions/role.actions';
 import { Workspace } from '../../../actions/workspace.actions';
 import { ButtonSet } from '../../buttons/button-set';
 import { Modal } from '../../../actions/modal.actions';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 
 
 export const RoleManagementPage = () => {
@@ -86,7 +86,7 @@ export const RoleManagementPage = () => {
     try {
       await axios.delete(`api/role/${orgId}/${roles[selectedRoleIndex].id}`);
     } catch (error) {
-      dispatch(Modal.alert('Delete Role', formatMessage(error, 'Unable to delete role')));
+      dispatch(Modal.alert('Delete Role', formatErrorMessage(error, 'Unable to delete role'))).then();
     }
     setDeleteRoleLoading(false);
     setDeleteRoleDialogOpen(false);

--- a/src/components/pages/roster-columns-page/edit-column-dialog.tsx
+++ b/src/components/pages/roster-columns-page/edit-column-dialog.tsx
@@ -30,7 +30,7 @@ import {
   rosterColumnTypeDisplayName,
 } from '../../../models/api-response';
 import { EditableBooleanTable } from '../../tables/editable-boolean-table';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 
 export interface EditColumnDialogProps {
   open: boolean,
@@ -166,7 +166,7 @@ export const EditColumnDialog = (props: EditColumnDialogProps) => {
       }
     } catch (error) {
       if (onError) {
-        onError(formatMessage(error));
+        onError(formatErrorMessage(error));
       }
       setFormDisabled(false);
       return;

--- a/src/components/pages/roster-columns-page/roster-columns-page.tsx
+++ b/src/components/pages/roster-columns-page/roster-columns-page.tsx
@@ -36,7 +36,7 @@ import { EditColumnDialog, EditColumnDialogProps } from './edit-column-dialog';
 import { AppFrame } from '../../../actions/app-frame.actions';
 import { ButtonSet } from '../../buttons/button-set';
 import { Modal } from '../../../actions/modal.actions';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 import { UserSelector } from '../../../selectors/user.selector';
 
 interface ColumnMenuState {
@@ -111,7 +111,7 @@ export const RosterColumnsPage = () => {
     try {
       await axios.delete(`api/roster/${orgId}/column/${columnToDelete.name}`);
     } catch (error) {
-      dispatch(Modal.alert('Delete Column', formatMessage(error, 'Unable to delete column'))).then();
+      dispatch(Modal.alert('Delete Column', formatErrorMessage(error, 'Unable to delete column'))).then();
     }
     setColumnToDelete(null);
     await initializeTable();

--- a/src/components/pages/roster-page/edit-roster-entry-dialog.tsx
+++ b/src/components/pages/roster-page/edit-roster-entry-dialog.tsx
@@ -25,7 +25,7 @@ import {
 import { ButtonWithSpinner } from '../../buttons/button-with-spinner';
 import { EditableBooleanTable } from '../../tables/editable-boolean-table';
 import { UnitSelector } from '../../../selectors/unit.selector';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 
 export interface EditRosterEntryDialogProps {
   open: boolean,
@@ -123,7 +123,7 @@ export const EditRosterEntryDialog = (props: EditRosterEntryDialogProps) => {
       }
     } catch (error) {
       if (onError) {
-        onError(formatMessage(error));
+        onError(formatErrorMessage(error));
       }
       setFormDisabled(false);
       return;

--- a/src/components/pages/settings-page/edit-alert-dialog.tsx
+++ b/src/components/pages/settings-page/edit-alert-dialog.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../../models/api-response';
 import { ButtonWithSpinner } from '../../buttons/button-with-spinner';
 import { buildSettingText } from './notifications-tab';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 
 export interface EditAlertDialogProps {
   open: boolean,
@@ -72,7 +72,7 @@ export const EditAlertDialog = (props: EditAlertDialogProps) => {
       }
     } catch (error) {
       if (onError) {
-        onError(formatMessage(error));
+        onError(formatErrorMessage(error));
       }
       setFormDisabled(false);
     }

--- a/src/components/pages/settings-page/notifications-tab.tsx
+++ b/src/components/pages/settings-page/notifications-tab.tsx
@@ -10,7 +10,7 @@ import useStyles from './notifications-tab.style';
 import { TabPanelProps } from './settings-page';
 import { EditAlertDialog, EditAlertDialogProps } from './edit-alert-dialog';
 import { Modal } from '../../../actions/modal.actions';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 import { UserSelector } from '../../../selectors/user.selector';
 
 interface NotificationSettings {
@@ -115,7 +115,7 @@ export const NotificationsTab = (props: TabPanelProps) => {
         return newState;
       });
     } catch (error) {
-      dispatch(Modal.alert('Error', formatMessage(error, 'An error occurred while saving the alert setting')));
+      dispatch(Modal.alert('Error', formatErrorMessage(error, 'An error occurred while saving the alert setting'))).then();
       await initializeTable();
     }
   };
@@ -146,7 +146,7 @@ export const NotificationsTab = (props: TabPanelProps) => {
       `Alerts within the StatusEngine application have been designed to give you the most up-to-date
       information on your group and users without overburdening your inbox or mobile device. Each alert topic
       has customizable parameters that allow you to tweak the alert type, threshold, frequency, and minimum
-      time between individual alerts.`));
+      time between individual alerts.`)).then();
   };
 
   useEffect(() => { initializeTable().then(); }, [initializeTable]);

--- a/src/components/pages/units-page/default-muster-dialog.tsx
+++ b/src/components/pages/units-page/default-muster-dialog.tsx
@@ -37,7 +37,7 @@ import { mustersConfigurationsAreEqual, validateMusterConfiguration } from '../.
 import { HelpCard } from '../../help/help-card/help-card';
 import { UnitSelector } from '../../../selectors/unit.selector';
 import { ReportSchemaSelector } from '../../../selectors/report-schema.selector';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 
 export interface DefaultMusterDialogProps {
   open: boolean,
@@ -253,7 +253,7 @@ export const DefaultMusterDialog = (props: DefaultMusterDialogProps) => {
       await axios.put(`api/org/${orgId}/default-muster`, body);
     } catch (error) {
       if (onError) {
-        onError(formatMessage(error));
+        onError(formatErrorMessage(error));
       }
       setFormDisabled(false);
       return;

--- a/src/components/pages/units-page/edit-unit-dialog.tsx
+++ b/src/components/pages/units-page/edit-unit-dialog.tsx
@@ -33,7 +33,7 @@ import { useSelector } from 'react-redux';
 import useStyles from './edit-unit-dialog.styles';
 import { ApiUnit, MusterConfiguration } from '../../../models/api-response';
 import { DaysOfTheWeek } from '../../../utility/days';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 import { ReportSchemaSelector } from '../../../selectors/report-schema.selector';
 import { mustersConfigurationsAreEqual, validateMusterConfiguration } from '../../../utility/muster-utils';
 
@@ -225,7 +225,7 @@ export const EditUnitDialog = (props: EditUnitDialogProps) => {
       }
     } catch (error) {
       if (onError) {
-        onError(formatMessage(error));
+        onError(formatErrorMessage(error));
       }
       setFormDisabled(false);
       return;

--- a/src/components/pages/units-page/units-page.tsx
+++ b/src/components/pages/units-page/units-page.tsx
@@ -43,7 +43,7 @@ import { Unit } from '../../../actions/unit.actions';
 import PageHeader from '../../page-header/page-header';
 import { musterConfigurationsToStrings } from '../../../utility/muster-utils';
 import { Modal } from '../../../actions/modal.actions';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 import { DefaultMusterDialog, DefaultMusterDialogProps } from './default-muster-dialog';
 import { User } from '../../../actions/user.actions';
 import { UserSelector } from '../../../selectors/user.selector';
@@ -121,7 +121,7 @@ export const UnitsPage = () => {
           await initializeTable();
         },
         onError: (message: string) => {
-          dispatch(Modal.alert('Edit Unit', `Unable to edit unit: ${message}`));
+          dispatch(Modal.alert('Edit Unit', `Unable to edit unit: ${message}`)).then();
         },
       });
     }
@@ -141,7 +141,7 @@ export const UnitsPage = () => {
     try {
       await axios.delete(`api/unit/${orgId}/${unitToDelete.id}`);
     } catch (error) {
-      dispatch(Modal.alert('Delete Unit', formatMessage(error, 'Unable to delete unit')));
+      dispatch(Modal.alert('Delete Unit', formatErrorMessage(error, 'Unable to delete unit'))).then();
     }
     setUnitToDelete(null);
     await initializeTable();

--- a/src/components/pages/users-page/users-page.tsx
+++ b/src/components/pages/users-page/users-page.tsx
@@ -29,7 +29,7 @@ import { ApiRole, ApiUser, ApiAccessRequest } from '../../../models/api-response
 import { AppFrame } from '../../../actions/app-frame.actions';
 import { ButtonWithSpinner } from '../../buttons/button-with-spinner';
 import SelectRoleDialog, { SelectRoleDialogProps } from './select-role-dialog';
-import { formatMessage } from '../../../utility/errors';
+import { formatErrorMessage } from '../../../utility/errors';
 import { UserSelector } from '../../../selectors/user.selector';
 import { Modal } from '../../../actions/modal.actions';
 import { UnitSelector } from '../../../selectors/unit.selector';
@@ -80,7 +80,7 @@ export const UsersPage = () => {
   }, [orgId, dispatch]);
 
   const showAlertDialog = (error: Error, title: string, message: string) => {
-    dispatch(Modal.alert(title, formatMessage(error, message))).then();
+    dispatch(Modal.alert(title, formatErrorMessage(error, message))).then();
   };
 
   const makeHandleUserMoreClick = (user: ApiUser) => (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/models/api-response.ts
+++ b/src/models/api-response.ts
@@ -241,8 +241,18 @@ export interface ApiUnit {
 }
 
 export interface ApiError {
-  errors: {
-    message: string
-    type: string
-  }[]
+  message: string
+  type: string
+}
+
+export interface ApiErrorResponseData {
+  errors: ApiError[]
+}
+
+export interface ApiErrorResponse {
+  data: ApiErrorResponseData
+}
+
+export interface ApiRosterUploadInfo {
+  count: number
 }

--- a/src/reducers/roster.reducer.ts
+++ b/src/reducers/roster.reducer.ts
@@ -15,12 +15,6 @@ export const rosterInitialState: RosterState = {
 
 export function rosterReducer(state = rosterInitialState, action: any) {
   switch (action.type) {
-    case Roster.Actions.Upload.type: {
-      // const payload = (action as Roster.Actions.Upload).payload;
-      return {
-        ...state,
-      };
-    }
     case Roster.Actions.FetchColumns.type: {
       return {
         ...state,

--- a/src/utility/axios.ts
+++ b/src/utility/axios.ts
@@ -1,5 +1,0 @@
-import { AxiosError } from 'axios';
-
-export function isAxiosError(err: any): err is AxiosError {
-  return (err.response != null);
-}

--- a/src/utility/errors.ts
+++ b/src/utility/errors.ts
@@ -1,12 +1,27 @@
-import { isAxiosError } from './axios';
+import _ from 'lodash';
+import { ApiErrorResponse } from '../models/api-response';
 
-export function formatMessage(error: Error, message = '', defaultErrorMessage = 'Internal Server Error', separator = '<br />') {
-  let errorMessage = defaultErrorMessage;
-  if (isAxiosError(error)) {
-    const errors = error?.response?.data?.errors;
-    if (errors?.length > 0) {
-      errorMessage = errors.map((err: any) => err.message).join(separator) ?? defaultErrorMessage;
-    }
+export function formatErrorMessage(error: Error, message = '', defaultErrorMessage = 'Internal Server Error') {
+  let errorMessage: string | undefined;
+
+  if (isApiErrorResponse(error)) {
+    const errors = error.data.errors;
+    errorMessage = errors.map(err => err.message)
+      .join('<br/><br/>')
+      .replaceAll('\n', '<br/>');
   }
-  return `${message}${message ? `: ${errorMessage}` : errorMessage}`;
+
+  if (!errorMessage) {
+    errorMessage = defaultErrorMessage;
+  }
+
+  if (message) {
+    return `${message}:<br/><br/>${errorMessage}`;
+  }
+
+  return errorMessage;
+}
+
+export function isApiErrorResponse(error: any): error is ApiErrorResponse {
+  return _.isArray(error?.data?.errors);
 }

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+database_exists() {
+  if psql -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER" -lqt | cut -d \| -f 1 | grep -qw "$SQL_DATABASE"; then
+    echo "1"
+  fi
+}
+
+create_database() {
+  echo -n "Creating '$SQL_DATABASE' database... "
+  createdb -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER" "$SQL_DATABASE" || {
+    echo "Failed to create '$SQL_DATABASE' database. Aborting..."
+    exit
+  }
+  echo "success!"
+}
+
+drop_database() {
+  echo -n "Dropping '$SQL_DATABASE' database... "
+  dropdb -h "$SQL_HOST" -p "$SQL_PORT" -U "$SQL_USER" "$SQL_DATABASE" || {
+    echo "Failed to drop '$SQL_DATABASE' database. Aborting..."
+    exit
+  }
+  echo "success!"
+}
+
+dir() {
+  cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd
+}


### PR DESCRIPTION
Hopefully you should now get useful error messages on the client for any issue you can think of in a roster csv upload.

There are now a couple typeorm utility functions for getting column metadata. They should be useful for reflecting any of that stuff when throwing validation errors.

I added a `getDatabaseErrorMessage()` function for catching errors on `entity.save()` calls. That should be like the fallback in case we don't catch the validation ourselves. If you enable logging in `ormconfig.ts` you can see what error code is coming back from the database on save and then handle it in that function.

I also did some refactoring around error handling in general to clean some stuff up and simplify a bit. The csv errors are probably a tiny bit less pretty on the client now, but I decided it was better to just keep the errors coming back in a consistent format for the sake of simplicity.

And, lastly, I refactored some repeated shell script code, just because it was annoying me.