### PR TITLE
Use basic confirm modal for roster entry delete.

### DIFF
--- a/src/actions/modal.actions.ts
+++ b/src/actions/modal.actions.ts
@@ -39,7 +39,28 @@ export namespace Modal {
     }) as unknown as Promise<ModalResponse>;
   };
 
-  export const confirm = (title: string, message: string, buttons: ModalButton[] = [{ text: 'OK' }, { text: 'Cancel' }]) => alert(title, message, buttons);
+  export const confirm = (title: string, message: string, options?: {
+    destructive?: boolean,
+    confirmText?: string,
+    cancelText?: string,
+  }) => {
+    const {
+      destructive = false,
+      confirmText = 'Confirm',
+      cancelText = 'Cancel',
+    } = options ?? {};
+
+    return alert(title, message, [{
+      text: confirmText,
+      value: true,
+      destructive,
+    }, {
+      text: cancelText,
+      value: false,
+      destructive: false,
+      variant: 'outlined',
+    }]);
+  };
 
   export const close = (title: string, response: ModalResponse) => (dispatch: Dispatch<Actions.Close>) => {
     dispatch(new Actions.Close({ title, response }));

--- a/src/components/modal/modal.styles.ts
+++ b/src/components/modal/modal.styles.ts
@@ -1,0 +1,11 @@
+import { createStyles, Theme } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+
+export default makeStyles((theme: Theme) => createStyles({
+  destructiveButton: {
+    backgroundColor: theme.palette.error.main,
+    '&:hover': {
+      backgroundColor: '#B6001D',
+    },
+  },
+}));

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,18 +1,30 @@
 import React from 'react';
 import {
   Button,
-  Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
 } from '@material-ui/core';
-import { useDispatch, useSelector } from 'react-redux';
+import {
+  useDispatch,
+  useSelector,
+} from 'react-redux';
 import { Modal as ModalActions } from '../../actions/modal.actions';
-import { ModalButton, ModalState } from '../../reducers/modal.reducer';
+import {
+  ModalButton,
+  ModalState,
+} from '../../reducers/modal.reducer';
 import { AppState } from '../../store';
+import useStyles from './modal.styles';
 
 const defaultButtons: ModalButton[] = [
   { text: 'Ok' },
 ];
 
 export const ModalProvider = () => {
+  const classes = useStyles();
   const { buttons, message, open, title } = useSelector<AppState, ModalState>(state => state.modal);
   const dispatch = useDispatch();
 
@@ -41,8 +53,13 @@ export const ModalProvider = () => {
         <div id="modal-provider-content" />
       </DialogContent>
       <DialogActions>
-        {(buttons ?? defaultButtons).map(({ text, ...rest }, index) => (
-          <Button key={text} onClick={() => onClose(index)} {...rest}>
+        {(buttons ?? defaultButtons).map(({ text, destructive, ...rest }, index) => (
+          <Button
+            key={text}
+            className={rest.className ?? (destructive) ? classes.destructiveButton : undefined}
+            onClick={() => onClose(index)}
+            {...rest}
+          >
             {text}
           </Button>
         ))}

--- a/src/components/pages/roster-page/roster-page.styles.ts
+++ b/src/components/pages/roster-page/roster-page.styles.ts
@@ -58,16 +58,4 @@ export default makeStyles((theme: Theme) => createStyles({
       fontWeight: 'bold',
     },
   },
-  deleteOrphanedMenuItem: {
-    color: theme.palette.error.main,
-    '&:hover': {
-      backgroundColor: '#B6001D20',
-    },
-  },
-  deleteOrphanedRecordConfirmButton: {
-    backgroundColor: theme.palette.error.main,
-    '&:hover': {
-      backgroundColor: '#B6001D',
-    },
-  },
 }));

--- a/src/reducers/modal.reducer.ts
+++ b/src/reducers/modal.reducer.ts
@@ -3,6 +3,7 @@ import { Modal } from '../actions/modal.actions';
 
 export interface ModalButton extends ButtonProps {
   text: string,
+  destructive?: boolean,
   value?: any,
 }
 


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200267961766824

Went with the quick fix option in the task description, which seems good enough for now. The functionality should be the same as before, but without a totally broken button.

I also enhanced the modal stuff slightly to support basic confirmation dialogs, with support for automatically styling destructive confirmations.