### PR TITLE
Use column display names in exported roster csv.

### DIFF
--- a/server/api/roster/roster.types.ts
+++ b/server/api/roster/roster.types.ts
@@ -79,7 +79,7 @@ export type RosterEntryData = {
   lastName?: RosterEntity['lastName'],
 } & CustomColumns;
 
-export type RosterFileRow = {
-  Unit: string
-  [columnName: string]: string
+export type RosterFileRow<TColumnValue = string> = {
+  Unit: TColumnValue
+  [columnDisplayName: string]: TColumnValue
 };


### PR DESCRIPTION
Exported roster CSVs were using camel case headers, inconsistent with the other CSV functions for the roster which use the display names for the header. Exported roster CSV headers should now look exactly like the others.