### PR TITLE
Roster CSV download/upload null value and date fixes.

### DIFF
--- a/server/api/export/export.controller.ts
+++ b/server/api/export/export.controller.ts
@@ -8,6 +8,10 @@ import { buildEsIndexPatternsForDataExport } from '../../util/elasticsearch-util
 import { InternalServerError } from '../../util/error-types';
 import { getRosterMusterStats } from '../../util/muster-utils';
 import {
+  getCsvHeaderForRosterColumn,
+  getCsvValueForRosterColumn,
+} from '../../util/roster-utils';
+import {
   TimeInterval,
 } from '../../util/util';
 import {
@@ -137,7 +141,8 @@ class ExportController {
           continue;
         }
 
-        row[column.displayName] = entry[columnName];
+        const header = getCsvHeaderForRosterColumn(column);
+        row[header] = getCsvValueForRosterColumn(entry, column);
       }
 
       return row;

--- a/server/api/roster/roster-entity.ts
+++ b/server/api/roster/roster-entity.ts
@@ -135,6 +135,9 @@ export abstract class RosterEntity extends BaseEntity {
       value = getOptionalValue(column.displayName, row, 'string');
     }
 
+    // Convert empty strings to null.
+    value = value || null;
+
     this.setColumnValue(column, value);
   }
 

--- a/server/api/roster/roster.controller.ts
+++ b/server/api/roster/roster.controller.ts
@@ -134,7 +134,7 @@ class RosterController {
             example.push('Example Text');
             break;
           case RosterColumnType.Date:
-            example.push(new Date().toLocaleDateString());
+            example.push(new Date().toISOString().split('T')[0]);
             break;
           case RosterColumnType.DateTime:
             example.push(new Date().toISOString());
@@ -220,7 +220,7 @@ class RosterController {
         if (err instanceof CsvRowError) {
           rowErrors.push(err);
         } else {
-          rowErrors.push(new CsvRowError(err.message, csvRow, rowIndex));
+          rowErrors.push(new CsvRowError(err, csvRow, rowIndex));
         }
         continue;
       }
@@ -526,7 +526,7 @@ function getRosterEntryFromCsvRow(csvRow: RosterFileRow, columns: RosterColumnIn
     try {
       entry.setColumnValueFromFileRow(column, csvRow);
     } catch (err) {
-      throw new CsvRowError(err.message, csvRow, rowIndex, column.displayName);
+      throw new CsvRowError(err, csvRow, rowIndex, column.displayName);
     }
   }
 

--- a/server/util/error-handler.ts
+++ b/server/util/error-handler.ts
@@ -17,6 +17,7 @@ export function errorHandler(error: any, req: Request, res: Response, next: Next
   let errors: ErrorData[];
 
   if (error.errors) {
+    error.errors.forEach(Log.error);
     statusCode = error.errors[0].statusCode;
     errors = error.errors.map(errorToData);
   } else {

--- a/server/util/error-types.ts
+++ b/server/util/error-types.ts
@@ -96,7 +96,14 @@ export class OrphanedRecordsNotFoundError extends RequestError {
 }
 
 export class CsvRowError extends RequestError {
-  constructor(message: string, row: RosterFileRow, rowIndex: number, columnDisplayName?: string, showErrorPage = false) {
+  constructor(messageOrError: string | Error, row: RosterFileRow, rowIndex: number, columnDisplayName?: string, showErrorPage = false) {
+    let message: string;
+    if (messageOrError instanceof Error) {
+      message = messageOrError.message;
+    } else {
+      message = messageOrError;
+    }
+
     // Offset by 2 (1 for being zero-based and 1 for the csv header row).
     const lineNumber = rowIndex + 2;
 
@@ -110,6 +117,10 @@ export class CsvRowError extends RequestError {
     super(`${lineInfo}\n${message}`, 'UnprocessableEntity', 422, showErrorPage);
 
     Error.captureStackTrace(this, CsvRowError);
+
+    if (messageOrError instanceof Error) {
+      this.stack! += `\nOriginal Error:\n${messageOrError.stack}`;
+    }
   }
 }
 

--- a/server/util/roster-utils.ts
+++ b/server/util/roster-utils.ts
@@ -3,7 +3,10 @@ import { Org } from '../api/org/org.model';
 import { Role } from '../api/role/role.model';
 import { RosterHistory } from '../api/roster/roster-history.model';
 import { Roster } from '../api/roster/roster.model';
-import { RosterEntryData } from '../api/roster/roster.types';
+import {
+  RosterColumnInfo,
+  RosterEntryData,
+} from '../api/roster/roster.types';
 import { Unit } from '../api/unit/unit.model';
 import { UserRole } from '../api/user/user-role.model';
 import {
@@ -101,4 +104,12 @@ export async function getRosterHistoryForIndividual(edipi: string, unitId: numbe
     .addOrderBy('rh.timestamp', 'DESC')
     .addOrderBy('rh.change_type', 'DESC')
     .getMany();
+}
+
+export function getCsvHeaderForRosterColumn(column: RosterColumnInfo) {
+  return column.displayName;
+}
+
+export function getCsvValueForRosterColumn(entry: RosterEntryData, column: RosterColumnInfo) {
+  return entry[column.name] ?? '';
 }


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200341565834207

When downloading a roster CSV, you should no longer see "null" as the value for null columns. They should be empty columns instead. And when uploading a roster CSV, empty column values will be treated as null when saved to the database.

I also fixed an issue where the roster CSV template would show different formats for example dates and datetimes. They should now be in a consistent iso format, with example dates stripping off the time part of the iso string.