### PR TITLE
Fix missing alert when edit orphan roster entry not found.

### DIFF
--- a/src/components/pages/roster-page/roster-page.tsx
+++ b/src/components/pages/roster-page/roster-page.tsx
@@ -509,7 +509,7 @@ export const RosterPage = () => {
   const editOrphanOnRosterClicked = async (row: ApiOrphanedRecord) => {
     const rosterEntry = await fetchRosterEntry(row);
     if (!rosterEntry) {
-      Modal.alert('Edit Roster Entry for Orphan', `Unable to find the roster entry`).then();
+      dispatch(Modal.alert('Edit Roster Entry for Orphan', `Unable to find the roster entry`)).then();
       return;
     }
     setEditRosterEntryDialogProps({


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200328258432981

There might still be a lingering issue if this error was even being hit in production. But this will at least fix the missing error. It might be worth having them try to reproduce it now that the rom hack has been removed in case that was causing an issue somehow.