### PR TITLE
Add unit filter to orphaned records table.

### DIFF
--- a/server/sqldb/seed-dev.ts
+++ b/server/sqldb/seed-dev.ts
@@ -53,7 +53,14 @@ export default (async function() {
     .execute();
 
   // Create lots of orphaned records to catch possible UI issues.
-  await seedOrphanedRecords(org1, { count: 1000 });
+  for (let i = 0; i < 10; i++) {
+    await seedOrphanedRecords(org1, {
+      count: 100,
+      customData: {
+        unit: uniqueString(),
+      },
+    });
+  }
 
   // Create some orphaned records that have the same composite id.
   await seedOrphanedRecords(org1, {

--- a/src/actions/orphaned-record.actions.ts
+++ b/src/actions/orphaned-record.actions.ts
@@ -29,10 +29,10 @@ export namespace OrphanedRecord {
     }
   }
 
-  export const fetchPage = (orgId: number, page: number, limit: number) => async (dispatch: Dispatch) => {
+  export const fetchPage = (orgId: number, page: number, limit: number, unit?: string) => async (dispatch: Dispatch) => {
     dispatch(new Actions.FetchPage());
     try {
-      const data = await OrphanedRecordClient.fetchPage(orgId, page, limit);
+      const data = await OrphanedRecordClient.fetchPage(orgId, page, limit, unit);
       dispatch(new Actions.FetchPageSuccess(data));
     } catch (error) {
       dispatch(new Actions.FetchPageFailure({ error }));

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -113,11 +113,12 @@ export namespace ReportSchemaClient {
 }
 
 export namespace OrphanedRecordClient {
-  export const fetchPage = (orgId: number, page: number, limit: number): Promise<ApiOrphanedRecordsPaginated> => {
+  export const fetchPage = (orgId: number, page: number, limit: number, unit?: string): Promise<ApiOrphanedRecordsPaginated> => {
     return client.get(`orphaned-record/${orgId}`, {
       params: {
         page,
         limit,
+        unit,
       },
     });
   };

--- a/src/components/app-sidenav/app-sidenav.tsx
+++ b/src/components/app-sidenav/app-sidenav.tsx
@@ -167,7 +167,7 @@ export const AppSidenav = () => {
               to="/roster"
               name="Roster"
               icon={(<AssignmentIndIcon />)}
-              badgeContent={orphanedRecords.totalRowsCount}
+              badgeContent={orphanedRecords.totalOrphanedRecordsCount}
             />
           )}
         </List>

--- a/src/components/pages/roster-page/roster-page.styles.ts
+++ b/src/components/pages/roster-page/roster-page.styles.ts
@@ -9,11 +9,11 @@ export default makeStyles((theme: Theme) => createStyles({
   fillWidth: {
     width: '100%',
   },
-  secondaryButtons: {
+  tableHeader: {
     marginLeft: theme.spacing(2),
     marginTop: theme.spacing(2),
   },
-  secondaryButton: {
+  tableHeaderButton: {
     borderWidth: 2,
     marginRight: theme.spacing(2),
 
@@ -21,7 +21,7 @@ export default makeStyles((theme: Theme) => createStyles({
       borderWidth: 2,
     },
   },
-  secondaryButtonCount: {
+  tableHeaderButtonCount: {
     backgroundColor: theme.palette.primary.main,
     borderRadius: '50%',
     color: '#fff',

--- a/src/models/api-response.ts
+++ b/src/models/api-response.ts
@@ -176,7 +176,10 @@ export interface ApiOrphanedRecord {
   rosterHistoryId?: number;
 }
 
-export interface ApiOrphanedRecordsPaginated extends ApiPaginated<ApiOrphanedRecord> {}
+export interface ApiOrphanedRecordsPaginated extends ApiPaginated<ApiOrphanedRecord> {
+  totalOrphanedRecordsCount: number
+  units: string[]
+}
 
 export interface ApiWorkspaceTemplate {
   id: number,

--- a/src/reducers/orphaned-record.reducer.ts
+++ b/src/reducers/orphaned-record.reducer.ts
@@ -4,6 +4,8 @@ import { ApiOrphanedRecord } from '../models/api-response';
 export interface OrphanedRecordState {
   rows: ApiOrphanedRecord[],
   totalRowsCount: number
+  totalOrphanedRecordsCount: number
+  units: string[]
   isLoading: boolean
   lastUpdated: number
 }
@@ -11,6 +13,8 @@ export interface OrphanedRecordState {
 export const orphanedRecordInitialState: OrphanedRecordState = {
   rows: [],
   totalRowsCount: 0,
+  totalOrphanedRecordsCount: 0,
+  units: [],
   isLoading: false,
   lastUpdated: 0,
 };
@@ -22,6 +26,8 @@ export function orphanedRecordReducer(state = orphanedRecordInitialState, action
         ...state,
         rows: [],
         totalRowsCount: 0,
+        totalOrphanedRecordsCount: 0,
+        units: [],
         isLoading: false,
         lastUpdated: Date.now(),
       };
@@ -33,11 +39,13 @@ export function orphanedRecordReducer(state = orphanedRecordInitialState, action
       };
     }
     case OrphanedRecord.Actions.FetchPageSuccess.type: {
-      const { rows, totalRowsCount } = (action as OrphanedRecord.Actions.FetchPageSuccess).payload;
+      const { rows, totalRowsCount, totalOrphanedRecordsCount, units } = (action as OrphanedRecord.Actions.FetchPageSuccess).payload;
       return {
         ...state,
         rows,
         totalRowsCount,
+        totalOrphanedRecordsCount,
+        units,
         isLoading: false,
         lastUpdated: Date.now(),
       };
@@ -47,6 +55,8 @@ export function orphanedRecordReducer(state = orphanedRecordInitialState, action
         ...state,
         rows: [],
         totalRowsCount: 0,
+        totalOrphanedRecordsCount: 0,
+        units: [],
         isLoading: false,
       };
     }


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200394516745667

This is a little hacky at the moment, but Roel was hoping to get it in quickly to demo to the person who requested it.

I tried to make it persistent, but in order to make that work right the units would have to be requested before the orphaned records, and there's also the potential issue of stale persisted data that no longer matches the unit names in the database.

There's a bug right now when you resolve the last orphaned record for a unit, where the Unit dropdown will blank out. It doesn't seem to really break anything though. It's just an empty filter that you can switch off of at that point.

Those aren't super tough issues to fix, but to fix them properly will take a little time. I figure I can make a polish pass tomorrow since I'm out of time for today and Roel wants this by the morning.

<img width="791" alt="Screen Shot 2021-06-02 at 2 44 59 PM" src="https://user-images.githubusercontent.com/3220897/120556276-20b08880-c3b1-11eb-98e6-38ed34e8d8fb.png">
