### PR TITLE
Orphaned records unit filter polish.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,7 +80,9 @@
     "react/jsx-props-no-spreading": "off",
     "react/no-array-index-key": "off",
     "react/require-default-props": "off",
-    "react-hooks/exhaustive-deps": "error",
+    "react-hooks/exhaustive-deps": ["error", {
+      "additionalHooks": "useEffectDebounced"
+    }],
     "space-before-function-paren": ["error", {
       "anonymous": "never",
       "named": "never",

--- a/server/api/orphaned-record/index.ts
+++ b/server/api/orphaned-record/index.ts
@@ -7,6 +7,13 @@ import { requireInternalUser, requireOrgAccess, requireRolePermission } from '..
 const router = express.Router() as any;
 
 router.get(
+  '/:orgId/count',
+  requireOrgAccess,
+  requireRolePermission(role => role.canManageRoster),
+  controller.getOrphanedRecordsCount,
+);
+
+router.get(
   '/:orgId',
   requireOrgAccess,
   requireRolePermission(role => role.canManageRoster),

--- a/server/sqldb/seed-dev.ts
+++ b/server/sqldb/seed-dev.ts
@@ -60,17 +60,17 @@ export default (async function() {
         unit: uniqueString(),
       },
     });
-  }
 
-  // Create some orphaned records that have the same composite id.
-  await seedOrphanedRecords(org1, {
-    count: 3,
-    customData: {
-      edipi: uniqueEdipi(),
-      unit: uniqueString(),
-      phone: uniquePhone(),
-    },
-  });
+    // Create some orphaned records that have the same composite id.
+    await seedOrphanedRecords(org1, {
+      count: 3,
+      customData: {
+        edipi: uniqueEdipi(),
+        unit: uniqueString(),
+        phone: uniquePhone(),
+      },
+    });
+  }
 
   // Create some orphaned records for an individual in the roster.
   await seedOrphanedRecords(org1, {

--- a/server/util/orphaned-records-utils.ts
+++ b/server/util/orphaned-records-utils.ts
@@ -35,34 +35,43 @@ export function deleteOrphanedRecordActionsForUser(
     .execute();
 }
 
-export function buildVisibleOrphanedRecordResultsQuery(userEdipi: string, orgId: number) {
+export async function getVisibleOrphanedRecordResultsCount(args: {
+  userEdipi: string
+  orgId: number
+}) {
+  const orphanedRecords = await getVisibleOrphanedRecordResults(args);
+  return orphanedRecords.length;
+}
+
+export async function getVisibleOrphanedRecordResults(args: {
+  userEdipi: string
+  orgId: number
+  unit?: string
+}) {
+  const { userEdipi, orgId, unit } = args;
+
   const params = {
     now: new Date(),
     orgId,
     userEdipi,
+    unit,
   };
 
-  const rosterEntries = RosterHistory.createQueryBuilder('rh')
-    .leftJoin('rh.unit', 'u')
-    .select('rh.id', 'id')
-    .addSelect('rh.edipi', 'edipi')
-    .addSelect('rh.timestamp', 'timestamp')
-    .addSelect('rh.change_type', 'change_type')
-    .addSelect('rh.unit_id', 'unit_id')
-    .where('u.org_id = :orgId', { orgId })
-    .distinctOn(['rh.unit_id', 'rh.edipi'])
-    .orderBy('rh.unit_id')
-    .addOrderBy('rh.edipi', 'DESC')
-    .addOrderBy('rh.timestamp', 'DESC')
-    .addOrderBy('rh.change_type', 'DESC');
+  const rosterEntries = buildRosterHistoryQuery(orgId);
 
-  return OrphanedRecord.createQueryBuilder('orphan')
+  const qb = OrphanedRecord.createQueryBuilder('orphan')
     .leftJoin(OrphanedRecordAction, 'action', `action.id=orphan.composite_id AND (action.expires_on > :now OR action.expires_on IS NULL) AND (action.type='claim' OR (action.user_edipi=:userEdipi AND action.type='ignore'))`, params)
     .leftJoin(`(${rosterEntries.getQuery()})`, 'roster', 'orphan.edipi = roster.edipi')
     .where('orphan.org_id=:orgId', params)
     .andWhere('orphan.deleted_on IS NULL')
     .andWhere(`(roster.change_type IS NULL OR roster.change_type <> 'deleted')`)
-    .andWhere(`(action.type IS NULL OR (action.type='claim' AND action.user_edipi=:userEdipi))`, params)
+    .andWhere(`(action.type IS NULL OR (action.type='claim' AND action.user_edipi=:userEdipi))`, params);
+
+  if (unit) {
+    qb.andWhere('orphan.unit LIKE :unit', { unit: `%${unit}%` });
+  }
+
+  return qb
     .select('orphan.edipi', 'edipi')
     .addSelect('orphan.unit', 'unit')
     .addSelect('orphan.phone', 'phone')
@@ -83,5 +92,36 @@ export function buildVisibleOrphanedRecordResultsQuery(userEdipi: string, orgId:
     .addGroupBy('action.type')
     .addGroupBy('action.expires_on')
     .addGroupBy('roster.unit_id')
-    .addGroupBy('roster.id');
+    .addGroupBy('roster.id')
+    .getRawMany<OrphanedRecordResult>();
+}
+
+function buildRosterHistoryQuery(orgId: number) {
+  return RosterHistory.createQueryBuilder('rh')
+    .leftJoin('rh.unit', 'u')
+    .select('rh.id', 'id')
+    .addSelect('rh.edipi', 'edipi')
+    .addSelect('rh.timestamp', 'timestamp')
+    .addSelect('rh.change_type', 'change_type')
+    .addSelect('rh.unit_id', 'unit_id')
+    .where('u.org_id = :orgId', { orgId })
+    .distinctOn(['rh.unit_id', 'rh.edipi'])
+    .orderBy('rh.unit_id')
+    .addOrderBy('rh.edipi', 'DESC')
+    .addOrderBy('rh.timestamp', 'DESC')
+    .addOrderBy('rh.change_type', 'DESC');
+}
+
+export interface OrphanedRecordResult {
+  id: string;
+  edipi: string;
+  phone: string;
+  unit: string;
+  count: number;
+  action?: string;
+  claimedUntil?: Date;
+  latestReportDate: Date;
+  earliestReportDate: Date;
+  unitId?: number;
+  rosterHistoryId?: number;
 }

--- a/src/actions/orphaned-record.actions.ts
+++ b/src/actions/orphaned-record.actions.ts
@@ -1,6 +1,9 @@
 import { Dispatch } from 'redux';
 import { OrphanedRecordClient } from '../client';
-import { ApiOrphanedRecordsPaginated } from '../models/api-response';
+import {
+  ApiOrphanedRecordsCount,
+  ApiOrphanedRecordsPaginated,
+} from '../models/api-response';
 
 export namespace OrphanedRecord {
 
@@ -9,6 +12,23 @@ export namespace OrphanedRecord {
     export class Clear {
       static type = 'ORPHANED_RECORD_CLEAR';
       type = Clear.type;
+    }
+
+    export class FetchCount {
+      static type = 'ORPHANED_RECORD_FETCH_COUNT';
+      type = FetchCount.type;
+    }
+    export class FetchCountSuccess {
+      static type = `${FetchCount.type}_SUCCESS`;
+      type = FetchCountSuccess.type;
+      constructor(public payload: ApiOrphanedRecordsCount) {}
+    }
+    export class FetchCountFailure {
+      static type = `${FetchCount.type}_FAILURE`;
+      type = FetchCountFailure.type;
+      constructor(public payload: {
+        error: any
+      }) {}
     }
 
     export class FetchPage {
@@ -25,9 +45,19 @@ export namespace OrphanedRecord {
       type = FetchPageFailure.type;
       constructor(public payload: {
         error: any
-      }) { }
+      }) {}
     }
   }
+
+  export const fetchCount = (orgId: number) => async (dispatch: Dispatch) => {
+    dispatch(new Actions.FetchCount());
+    try {
+      const data = await OrphanedRecordClient.fetchCount(orgId);
+      dispatch(new Actions.FetchCountSuccess(data));
+    } catch (error) {
+      dispatch(new Actions.FetchCountFailure({ error }));
+    }
+  };
 
   export const fetchPage = (orgId: number, page: number, limit: number, unit?: string) => async (dispatch: Dispatch) => {
     dispatch(new Actions.FetchPage());

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -8,6 +8,7 @@ import {
   ApiAccessRequest,
   ApiDashboard,
   ApiNotification,
+  ApiOrphanedRecordsCount,
   ApiOrphanedRecordsPaginated,
   ApiReportSchema,
   ApiRole,
@@ -113,6 +114,10 @@ export namespace ReportSchemaClient {
 }
 
 export namespace OrphanedRecordClient {
+  export const fetchCount = (orgId: number): Promise<ApiOrphanedRecordsCount> => {
+    return client.get(`orphaned-record/${orgId}/count`);
+  };
+
   export const fetchPage = (orgId: number, page: number, limit: number, unit?: string): Promise<ApiOrphanedRecordsPaginated> => {
     return client.get(`orphaned-record/${orgId}`, {
       params: {

--- a/src/components/app-sidenav/app-sidenav.tsx
+++ b/src/components/app-sidenav/app-sidenav.tsx
@@ -96,8 +96,7 @@ export const AppSidenav = () => {
 
   useEffect(() => {
     if (user.activeRole?.role.canManageRoster) {
-      // Set the limit to 0 here since we only need the total rows count for the Roster badge.
-      dispatch(OrphanedRecord.fetchPage(orgId!, 0, 0));
+      dispatch(OrphanedRecord.fetchCount(orgId!));
     } else {
       dispatch(OrphanedRecord.clear());
     }
@@ -167,7 +166,7 @@ export const AppSidenav = () => {
               to="/roster"
               name="Roster"
               icon={(<AssignmentIndIcon />)}
-              badgeContent={orphanedRecords.totalOrphanedRecordsCount}
+              badgeContent={orphanedRecords.count}
             />
           )}
         </List>

--- a/src/components/pages/roster-page/roster-page.styles.ts
+++ b/src/components/pages/roster-page/roster-page.styles.ts
@@ -53,6 +53,9 @@ export default makeStyles((theme: Theme) => createStyles({
   table: {
     marginBottom: '39px',
   },
+  orphanUnitFilterTextField: {
+    margin: `0 ${theme.spacing(1)}px`,
+  },
   claimedOrphanRow: {
     '& td': {
       fontWeight: 'bold',

--- a/src/components/pages/users-page/users-page.tsx
+++ b/src/components/pages/users-page/users-page.tsx
@@ -57,7 +57,7 @@ export const UsersPage = () => {
     accessRequest: undefined as ApiAccessRequest | undefined,
   });
 
-  const { edipi: currentUserEdipi } = useSelector(UserSelector.current);
+  const { edipi: currentUserEdipi } = useSelector(UserSelector.root);
   const { id: orgId, name: orgName } = useSelector(UserSelector.org) ?? {};
 
   const initializeTable = React.useCallback(async () => {

--- a/src/components/query-builder/query-builder.tsx
+++ b/src/components/query-builder/query-builder.tsx
@@ -1,16 +1,25 @@
-import React, { useEffect } from 'react';
+import MomentUtils from '@date-io/moment';
 import {
-  Button, Collapse, Grid, IconButton, Select, Switch, TextField,
+  Button,
+  Collapse,
+  Grid,
+  IconButton,
+  Select,
+  Switch,
+  TextField,
 } from '@material-ui/core';
 import AddCircleIcon from '@material-ui/icons/AddCircle';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
-import MomentUtils from '@date-io/moment';
-import { DatePicker, DateTimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
+import {
+  DatePicker,
+  DateTimePicker,
+  MuiPickersUtilsProvider,
+} from '@material-ui/pickers';
 import moment, { Moment } from 'moment';
-import useStyles from './query-builder.styles';
-import useDebounced from '../../hooks/use-debounced';
+import React, { useEffect } from 'react';
 import useDeepEquality from '../../hooks/use-deep-equality';
 import usePersistedState from '../../hooks/use-persisted-state';
+import useStyles from './query-builder.styles';
 
 const toDate = (date: Moment) => date.format('YYYY-MM-DD');
 
@@ -100,7 +109,7 @@ const DateTimeValue = ({ hasTime, onChange, row }: DateTimeValueEditorProps) => 
     if (!row.value) {
       onChange({ ...row, value: getDefaultValueForType(row.field) });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const Picker = hasTime ? DateTimePicker : DatePicker;
@@ -413,7 +422,6 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
   const [rows, setRows] = usePersistedState<QueryRow[]>(persistKey, []);
   const availableFields = fields.filter(field => !rows.some(row => row.field.name === field.name));
   const [filterState, setFilterState] = useDeepEquality<QueryFilterState | undefined>();
-  const debouncedRows = useDebounced(rows, 333);
 
   const addRow = () => {
     if (availableFields.length > 0) {
@@ -434,13 +442,13 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
   };
 
   useEffect(() => {
-    const queryableRows = debouncedRows.filter(row => row.field && row.value !== '');
+    const queryableRows = rows.filter(row => row.field && row.value !== '');
     const query: QueryFilterState = {};
     for (const { field, op, value } of queryableRows) {
       query[field!.name] = { op, value };
     }
     setFilterState(queryableRows.length ? query : undefined);
-  }, [debouncedRows, setFilterState]);
+  }, [rows, setFilterState]);
 
   useEffect(() => {
     onChange(filterState);
@@ -450,7 +458,7 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
     if (open && rows.length === 0) {
       addRow();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   return (

--- a/src/hooks/use-effect-debounced.ts
+++ b/src/hooks/use-effect-debounced.ts
@@ -1,0 +1,16 @@
+import {
+  DependencyList,
+  EffectCallback,
+  useEffect,
+  useRef,
+} from 'react';
+
+export default function useEffectDebounced(effect: EffectCallback, deps?: DependencyList, delay = 500) {
+  const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    clearTimeout(timeout.current!);
+    timeout.current = setTimeout(effect, delay);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/src/hooks/use-initial-loading.ts
+++ b/src/hooks/use-initial-loading.ts
@@ -1,0 +1,18 @@
+import {
+  useCallback,
+  useState,
+} from 'react';
+
+export default function useInitialLoading() {
+  const [initialLoadStep, setInitialLoadStep] = useState(0);
+  const [initialLoadComplete, setInitialLoadComplete] = useState(false);
+
+  const incrementInitialLoadStep = useCallback((isFinalStep = false) => {
+    setInitialLoadStep(initialLoadStep + 1);
+    if (isFinalStep) {
+      setInitialLoadComplete(true);
+    }
+  }, [initialLoadStep]);
+
+  return [initialLoadStep, incrementInitialLoadStep, initialLoadComplete] as const;
+}

--- a/src/models/api-response.ts
+++ b/src/models/api-response.ts
@@ -176,9 +176,10 @@ export interface ApiOrphanedRecord {
   rosterHistoryId?: number;
 }
 
-export interface ApiOrphanedRecordsPaginated extends ApiPaginated<ApiOrphanedRecord> {
-  totalOrphanedRecordsCount: number
-  units: string[]
+export interface ApiOrphanedRecordsPaginated extends ApiPaginated<ApiOrphanedRecord> {}
+
+export interface ApiOrphanedRecordsCount {
+  count: number
 }
 
 export interface ApiWorkspaceTemplate {

--- a/src/reducers/orphaned-record.reducer.ts
+++ b/src/reducers/orphaned-record.reducer.ts
@@ -4,60 +4,67 @@ import { ApiOrphanedRecord } from '../models/api-response';
 export interface OrphanedRecordState {
   rows: ApiOrphanedRecord[],
   totalRowsCount: number
-  totalOrphanedRecordsCount: number
-  units: string[]
-  isLoading: boolean
+  count: number
+  countLoading: boolean
+  pageLoading: boolean
   lastUpdated: number
 }
 
 export const orphanedRecordInitialState: OrphanedRecordState = {
   rows: [],
   totalRowsCount: 0,
-  totalOrphanedRecordsCount: 0,
-  units: [],
-  isLoading: false,
+  count: 0,
+  countLoading: false,
+  pageLoading: false,
   lastUpdated: 0,
 };
 
 export function orphanedRecordReducer(state = orphanedRecordInitialState, action: any): OrphanedRecordState {
   switch (action.type) {
     case OrphanedRecord.Actions.Clear.type: {
+      return { ...orphanedRecordInitialState };
+    }
+    case OrphanedRecord.Actions.FetchCount.type: {
       return {
         ...state,
-        rows: [],
-        totalRowsCount: 0,
-        totalOrphanedRecordsCount: 0,
-        units: [],
-        isLoading: false,
+        countLoading: true,
+      };
+    }
+    case OrphanedRecord.Actions.FetchCountSuccess.type: {
+      const { count } = (action as OrphanedRecord.Actions.FetchCountSuccess).payload;
+      return {
+        ...state,
+        count,
+        countLoading: false,
         lastUpdated: Date.now(),
+      };
+    }
+    case OrphanedRecord.Actions.FetchCountFailure.type: {
+      return {
+        ...state,
+        countLoading: false,
       };
     }
     case OrphanedRecord.Actions.FetchPage.type: {
       return {
         ...state,
-        isLoading: true,
+        pageLoading: true,
       };
     }
     case OrphanedRecord.Actions.FetchPageSuccess.type: {
-      const { rows, totalRowsCount, totalOrphanedRecordsCount, units } = (action as OrphanedRecord.Actions.FetchPageSuccess).payload;
+      const { rows, totalRowsCount } = (action as OrphanedRecord.Actions.FetchPageSuccess).payload;
       return {
         ...state,
         rows,
         totalRowsCount,
-        totalOrphanedRecordsCount,
-        units,
-        isLoading: false,
+        pageLoading: false,
         lastUpdated: Date.now(),
       };
     }
     case OrphanedRecord.Actions.FetchPageFailure.type: {
       return {
         ...state,
-        rows: [],
-        totalRowsCount: 0,
-        totalOrphanedRecordsCount: 0,
-        units: [],
-        isLoading: false,
+        pageLoading: false,
       };
     }
     default:

--- a/src/selectors/user.selector.ts
+++ b/src/selectors/user.selector.ts
@@ -1,9 +1,10 @@
 import { AppState } from '../store';
 
 export namespace UserSelector {
-  export const current = (state: AppState) => state.user;
+  export const root = (state: AppState) => state.user;
   export const orgId = (state: AppState) => state.user.activeRole?.role.org?.id;
   export const org = (state: AppState) => state.user.activeRole?.role.org;
   export const workspaces = (state: AppState) => state.user.activeRole?.role.workspaces;
   export const favoriteDashboards = (state: AppState) => state.user.activeRole?.favoriteDashboards;
+  export const canManageRoster = (state: AppState) => Boolean(state.user.activeRole?.role.canManageRoster);
 }


### PR DESCRIPTION
- Added persistence to the orphaned records unit filter.

- Switched orphaned records unit filter to text input to avoid too much quirky behavior related to persistence with dropdown.

- Added `useEffectDebounced` hook to make debouncing requests easier. I noticed there was a `useDebounced` hook already, but it seems to be a wrapper for `useState`. I also removed the use of it in the query builder, since I wanted to debounce the roster requests at the effect level, but with `useDebounced` in the query builder the debounce timeouts were accumulating. I figure it's probably better to let debouncing be controlled outside of the query builder anyways.

- Added `useInitialLoading` hook to aid in initial loads that require sequential data requests. I've been trying to figure out a better solution for this, but can't find anything on the internet that I like any better than this solution. It would be preferable to be able to pass an array of callbacks in and manage all of the loading state within the hook, but react won't let me call `useEffect` within a loop since it violates their hook rules. Let me know if you come across a better solution for this.

- Added an orphaned record count endpoint. It's slightly redundant implementation-wise, but the interface was confusing before having to request a page to get the total count.

<img width="793" alt="Screen Shot 2021-06-07 at 6 20 29 PM" src="https://user-images.githubusercontent.com/3220897/121107598-0e718880-c7bd-11eb-85c7-c033c3f2bcf5.png">
