### PR TITLE
Muster page improvements.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "form-data": "^2.3.3",
         "http-proxy-middleware": "^0.20.0",
         "json-2-csv": "^3.7.8",
+        "libphonenumber-js": "^1.9.19",
         "lodash": "^4.17.20",
         "material-ui-phone-number": "^2.2.6",
         "mocha": "^8.2.1",
@@ -17012,6 +17013,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.9.19",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.19.tgz",
+      "integrity": "sha512-RjStfSE63LvXQEBw7pgQHPkY35z8feiMjC9wLvL1Hbt8PbhxpRrACwMXmLQgabb+IpVdcEx+olh8ll7UDXXkfA=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
@@ -44912,6 +44918,11 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "libphonenumber-js": {
+      "version": "1.9.19",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.19.tgz",
+      "integrity": "sha512-RjStfSE63LvXQEBw7pgQHPkY35z8feiMjC9wLvL1Hbt8PbhxpRrACwMXmLQgabb+IpVdcEx+olh8ll7UDXXkfA=="
     },
     "lines-and-columns": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "form-data": "^2.3.3",
     "http-proxy-middleware": "^0.20.0",
     "json-2-csv": "^3.7.8",
+    "libphonenumber-js": "^1.9.19",
     "lodash": "^4.17.20",
     "material-ui-phone-number": "^2.2.6",
     "mocha": "^8.2.1",

--- a/server/api/export/export.controller.ts
+++ b/server/api/export/export.controller.ts
@@ -6,7 +6,7 @@ import { elasticsearch } from '../../elasticsearch/elasticsearch';
 import { assertRequestQuery } from '../../util/api-utils';
 import { buildEsIndexPatternsForDataExport } from '../../util/elasticsearch-utils';
 import { InternalServerError } from '../../util/error-types';
-import { getRosterMusterStats } from '../../util/muster-utils';
+import { getMusterRosterStats } from '../../util/muster-utils';
 import {
   getCsvHeaderForRosterColumn,
   getCsvValueForRosterColumn,
@@ -152,7 +152,7 @@ class ExportController {
     res.send(csv);
   }
 
-  async exportMusterIndividualsToCsv(req: ApiRequest<OrgParam, null, ExportMusterIndividualsQuery>, res: Response) {
+  async exportMusterRosterToCsv(req: ApiRequest<OrgParam, null, ExportMusterIndividualsQuery>, res: Response) {
     assertRequestQuery(req, [
       'fromDate',
       'toDate',
@@ -161,7 +161,7 @@ class ExportController {
     const fromDate = moment(req.query.fromDate);
     const toDate = moment(req.query.toDate);
 
-    const individuals = await getRosterMusterStats({
+    const individuals = await getMusterRosterStats({
       org: req.appOrg!,
       userRole: req.appUserRole!,
       unitId: req.query.unitId,
@@ -177,7 +177,7 @@ class ExportController {
     const csv = await json2csvAsync(individuals);
 
     res.header('Content-Type', 'text/csv');
-    res.attachment('muster-noncompliance.csv');
+    res.attachment('muster-compliance.csv');
     res.send(csv);
   }
 

--- a/server/api/export/index.ts
+++ b/server/api/export/index.ts
@@ -21,10 +21,10 @@ router.get(
 );
 
 router.get(
-  '/:orgId/muster/individuals',
+  '/:orgId/muster/roster',
   requireOrgAccess,
   requireRolePermission(role => role.canViewMuster),
-  controller.exportMusterIndividualsToCsv,
+  controller.exportMusterRosterToCsv,
 );
 
 export default router;

--- a/server/api/muster/index.ts
+++ b/server/api/muster/index.ts
@@ -18,17 +18,17 @@ router.get(
 );
 
 router.get(
-  '/:orgId/individuals',
+  '/:orgId/roster',
   requireOrgAccess,
   requireRolePermission(role => role.canViewMuster),
-  controller.getIndividuals,
+  controller.getMusterRoster,
 );
 
 router.get(
-  '/:orgId/trends',
+  '/:orgId/unit-trends',
   requireOrgAccess,
   requireRolePermission(role => role.canViewMuster),
-  controller.getTrends,
+  controller.getMusterUnitTrends,
 );
 
 export default router;

--- a/server/api/muster/muster.controller.ts
+++ b/server/api/muster/muster.controller.ts
@@ -8,8 +8,8 @@ import {
   getDistanceToWindow,
   getEarliestMusterWindowTime,
   getOneTimeMusterWindowTime,
-  getRosterMusterStats,
-  getUnitMusterStats,
+  getMusterRosterStats,
+  getMusterUnitTrends,
   MusterWindow,
 } from '../../util/muster-utils';
 import {
@@ -33,7 +33,7 @@ import {
 
 class MusterController {
 
-  async getIndividuals(req: ApiRequest<OrgRoleParams, null, GetIndividualsQuery>, res: Response<Paginated<Partial<Roster>>>) {
+  async getMusterRoster(req: ApiRequest<OrgRoleParams, null, GetMusterRosterQuery>, res: Response<Paginated<Partial<Roster>>>) {
     assertRequestQuery(req, [
       'fromDate',
       'toDate',
@@ -46,7 +46,7 @@ class MusterController {
     const limit = parseInt(req.query.limit);
     const page = parseInt(req.query.page);
 
-    const individuals = await getRosterMusterStats({
+    const rosterStats = await getMusterRosterStats({
       org: req.appOrg!,
       userRole: req.appUserRole!,
       unitId: req.query.unitId || undefined,
@@ -57,12 +57,12 @@ class MusterController {
     const offset = page * limit;
 
     return res.json({
-      rows: individuals.slice(offset, offset + limit),
-      totalRowsCount: individuals.length,
+      rows: rosterStats.slice(offset, offset + limit),
+      totalRowsCount: rosterStats.length,
     });
   }
 
-  async getTrends(req: ApiRequest<null, null, GetTrendsQuery>, res: Response) {
+  async getMusterUnitTrends(req: ApiRequest<null, null, GetMusterUnitTrendsQuery>, res: Response) {
     assertRequestQuery(req, [
       'currentDate',
       'weeksCount',
@@ -73,7 +73,7 @@ class MusterController {
     const weeksCount = parseInt(req.query.weeksCount ?? '6');
     const monthsCount = parseInt(req.query.monthsCount ?? '6');
 
-    const unitTrends = await getUnitMusterStats({
+    const unitTrends = await getMusterUnitTrends({
       userRole: req.appUserRole!,
       currentDate,
       weeksCount,
@@ -216,13 +216,13 @@ class MusterController {
   }
 }
 
-type GetIndividualsQuery = {
+type GetMusterRosterQuery = {
   fromDate: string
   toDate: string
   unitId: number | null
 } & PaginatedQuery;
 
-type GetTrendsQuery = {
+type GetMusterUnitTrendsQuery = {
   currentDate: string
   weeksCount?: string
   monthsCount?: string

--- a/server/api/user/user.controller.spec.ts
+++ b/server/api/user/user.controller.spec.ts
@@ -51,7 +51,7 @@ describe(`User Controller`, () => {
       const body = {
         firstName: uniqueString(),
         lastName: uniqueString(),
-        phone: '1234567890',
+        phone: '5551234567',
         email: uniqueEmail(),
         service: 'Space Force',
       };
@@ -65,7 +65,7 @@ describe(`User Controller`, () => {
       expect(userAfter).to.containSubset({
         ...body,
         edipi,
-        phone: '123-456-7890',
+        phone: '(555) 123-4567',
       });
 
       expect(await User.count()).to.equal(usersCountBefore + 1);

--- a/server/migration/1623276130329-FormatPhoneNumbers.ts
+++ b/server/migration/1623276130329-FormatPhoneNumbers.ts
@@ -1,0 +1,57 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+} from 'typeorm';
+import { formatNumber } from 'libphonenumber-js';
+
+export class FormatPhoneNumbers1623276130329 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await updatePhoneNumbers(queryRunner, phone => formatNumber(phone, 'US', 'NATIONAL'));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await updatePhoneNumbers(queryRunner, phone => {
+      const phoneDigits = phone.replace(/\D/g, '');
+      return (phoneDigits.length === 10)
+        ? `${phoneDigits.slice(0, 3)}-${phoneDigits.slice(3, 6)}-${phoneDigits.slice(6)}`
+        : phone;
+    });
+  }
+
+}
+
+async function updatePhoneNumbers(queryRunner: QueryRunner, formatter: (phone: string) => string) {
+  // Orphaned records.
+  const orphanedRecords = await queryRunner.query(`SELECT "document_id", "phone" FROM "orphaned_record"`) as Array<{
+    document_id: string
+    phone: string
+  }>;
+
+  for (const row of orphanedRecords) {
+    row.phone = formatter(row.phone);
+    await queryRunner.query(`UPDATE "orphaned_record" SET "phone" = $1 WHERE "document_id" = $2`, [row.phone, row.document_id]);
+  }
+
+  // Access requests.
+  const accessRequests = await queryRunner.query(`SELECT "id", "sponsor_phone" FROM "access_request"`) as Array<{
+    id: number
+    sponsor_phone: string
+  }>;
+
+  for (const row of accessRequests) {
+    row.sponsor_phone = formatter(row.sponsor_phone);
+    await queryRunner.query(`UPDATE "access_request" SET "sponsor_phone" = $1 WHERE "id" = $2`, [row.sponsor_phone, row.id]);
+  }
+
+  // Users.
+  const users = await queryRunner.query(`SELECT "edipi", "phone" FROM "user"`) as Array<{
+    edipi: string
+    phone: string
+  }>;
+
+  for (const row of users) {
+    row.phone = formatter(row.phone);
+    await queryRunner.query(`UPDATE "user" SET "phone" = $1 WHERE "edipi" = $2`, [row.phone, row.edipi]);
+  }
+}

--- a/server/util/math-utils.ts
+++ b/server/util/math-utils.ts
@@ -1,0 +1,6 @@
+export function diffEpsilon(a: number, b: number, epsilon = 0.001) {
+  const diff = a - b;
+  return Math.abs(diff) < epsilon
+    ? 0
+    : diff;
+}

--- a/server/util/muster-utils.ts
+++ b/server/util/muster-utils.ts
@@ -18,6 +18,7 @@ import {
   getMomentDateFormat,
   TimeInterval,
 } from './util';
+import { diffEpsilon } from './math-utils';
 
 /**
  * Get muster stats for each individual on the roster, given a time range and optional unit to filter by. The returned
@@ -143,9 +144,8 @@ export async function getMusterRosterStats(args: {
   }
 
   // Calculate muster percents.
-  for (const edipi of Object.keys(rosterStats)) {
-    const data = rosterStats[edipi];
-    rosterStats[edipi].musterPercent = calcMusterPercent(data.totalMusters, data.mustersReported);
+  for (const stats of Object.values(rosterStats)) {
+    stats.musterPercent = calcMusterPercent(stats.totalMusters, stats.mustersReported);
   }
 
   // Return a sorted array of the individuals' stats merged with their roster data.
@@ -159,7 +159,7 @@ export async function getMusterRosterStats(args: {
       const individualA = rosterStats[edipiA];
       const individualB = rosterStats[edipiB];
 
-      let diff = individualA.musterPercent - individualB.musterPercent;
+      let diff = diffEpsilon(individualA.musterPercent, individualB.musterPercent);
       if (diff === 0) {
         diff = entryA.unit?.name.localeCompare(entryB.unit!.name) ?? 0;
       }

--- a/server/util/string-utils.ts
+++ b/server/util/string-utils.ts
@@ -1,9 +1,5 @@
+import { formatNumber } from 'libphonenumber-js';
+
 export function formatPhoneNumber(phone: string) {
-  const phoneDigits = phone.replace(/\D/g, '');
-
-  if (phoneDigits.length === 10) {
-    return `${phoneDigits.slice(0, 3)}-${phoneDigits.slice(3, 6)}-${phoneDigits.slice(6)}`;
-  }
-
-  return phone;
+  return formatNumber(phone, 'US', 'NATIONAL');
 }

--- a/server/util/test-utils/unique.ts
+++ b/server/util/test-utils/unique.ts
@@ -1,31 +1,36 @@
-const intGen = (function* (): Generator<number, number, void> {
-  let nextInt = 0;
-  while (true) {
-    yield nextInt;
-    nextInt += 1;
-  }
-}());
-
+let intCount = 0;
 export function uniqueInt() {
-  return intGen.next().value;
+  intCount += 1;
+  return intCount;
 }
 
+let stringCount = 0;
 export function uniqueString() {
-  return `${uniqueInt()}`;
+  stringCount += 1;
+  return `${stringCount}`;
 }
 
+let dateCount = 0;
 export function uniqueDate() {
-  return new Date(uniqueInt());
+  dateCount += 1;
+  return new Date(dateCount);
 }
 
+let edipiCount = 0;
 export function uniqueEdipi() {
-  return `${uniqueInt()}`.padStart(10, '0');
+  edipiCount += 1;
+  return `${edipiCount}`.padStart(10, '0');
 }
 
+let emailCount = 0;
 export function uniqueEmail() {
-  return `${uniqueString()}@statusenginetest.com`;
+  emailCount += 1;
+  return `${emailCount}@setest.com`;
 }
 
+let phoneCount = 0;
 export function uniquePhone() {
-  return `${uniqueInt()}`.padStart(10, '0');
+  phoneCount += 1;
+  const last7 = phoneCount.toString().slice(-7).padStart(7, '0');
+  return `(555) ${last7.slice(0, 3)}-${last7.slice(3)}`;
 }

--- a/src/components/pages/muster-page/muster-page-help.tsx
+++ b/src/components/pages/muster-page/muster-page-help.tsx
@@ -5,14 +5,14 @@ export const MusterPageHelp = () => {
   return (
     <PageHelp
       description={`
-        This view highlights individuals and units who have a higher than normal Non-muster Rate per their established
+        This view highlights individuals and units who have a lower than normal muster rate per their established
         muster requirements. The table displays the individuals, while the two graphs (below) show offending units by
         weekly and monthly trends.
       `}
       bullets={[
-        'Identify individuals who have a high Non-muster Rate',
-        'Identify units that have a high Non-muster Rate',
-        `Export a CSV file containing all non-compliant individuals' muster data`,
+        'Identify individuals who have a low muster rate',
+        'Identify units that have a low muster rate',
+        `Export a CSV file containing all individuals' muster data`,
       ]}
     />
   );

--- a/src/models/api-response.ts
+++ b/src/models/api-response.ts
@@ -209,14 +209,20 @@ export interface ApiDashboard {
 export interface ApiUnitStatsByDate {
   [date: string]: {
     [unitName: string]: {
+      totalMusters: number
       mustersReported: number
-      mustersNotReported: number
-      nonMusterPercent: number
+      musterPercent: number
     }
   }
 }
 
-export interface ApiMusterIndividualsPaginated extends ApiPaginated<ApiRosterEntry> {}
+export interface ApiMusterRosterEntry extends ApiRosterEntry {
+  totalMusters: number
+  mustersReported: number
+  musterPercent: number
+}
+
+export interface ApiMusterRosterEntriesPaginated extends ApiPaginated<ApiMusterRosterEntry> {}
 
 export interface ApiMusterTrends {
   weekly: ApiUnitStatsByDate

--- a/src/utility/validation-utils.ts
+++ b/src/utility/validation-utils.ts
@@ -1,3 +1,5 @@
+import { isValidPhoneNumber } from 'libphonenumber-js';
+
 // from: https://stackoverflow.com/questions/46155/how-to-validate-an-email-address-in-javascript
 export function validateEmail(email: string) {
   const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -5,6 +7,5 @@ export function validateEmail(email: string) {
 }
 
 export function validatePhone(phone: string) {
-  const numeric = phone.replace(/\D/g, '');
-  return numeric.length === 10;
+  return isValidPhoneNumber(phone, 'US');
 }


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200394516745665
https://app.asana.com/0/1188940305683068/1200416265664999
https://app.asana.com/0/1188940305683068/1200416265665005
https://app.asana.com/0/1188940305683068/1200435628945373

- Flip "muster non-compliance" and "non-muster rate" to "muster compliance" and "muster rate" (except for unit non-compliance trend graphs).

- Show all users in Muster page, even if they're fully compliant. This was a user request, since they were confused about why some users weren't showing up in that page.

- Persist all inputs in Muster page.

- Normalize phone numbers to `(xxx) xxx-xxxx` format across the database, and as they're pulled from Elasticsearch

- Some renaming of functions and variables to make things more consistent/explicit. Most of them involve renaming things from `individuals` to `roster`.

- Update dev seed data to be a little cleaner.

## Screenshots
<img width="1237" alt="Screen Shot 2021-06-11 at 10 49 08 AM" src="https://user-images.githubusercontent.com/3220897/121728888-b24f8280-caa2-11eb-9e74-11d033a30f52.png">

<img width="1238" alt="Screen Shot 2021-06-11 at 10 35 53 AM" src="https://user-images.githubusercontent.com/3220897/121728550-453bed00-caa2-11eb-88a2-4e5a6e316639.png">
