### PR TITLE
Use more precise trigger disabling in migration.

### DIFF
--- a/packages/server/src/migration/1623276130329-FormatPhoneNumbers.ts
+++ b/packages/server/src/migration/1623276130329-FormatPhoneNumbers.ts
@@ -72,7 +72,8 @@ async function updatePhoneNumbers(queryRunner: QueryRunner, formatter: (phone: s
   }>;
 
   // Disable triggers temporarily on roster to avoid roster history updates.
-  await queryRunner.query(`ALTER TABLE "roster" DISABLE TRIGGER ALL`);
+  await queryRunner.query(`ALTER TABLE "roster" DISABLE TRIGGER "roster_audit"`);
+  await queryRunner.query(`ALTER TABLE "roster" DISABLE TRIGGER "roster_truncate"`);
 
   for (const row of rosterEntries) {
     for (const [columnName, columnValue] of Object.entries(row.custom_columns)) {
@@ -85,7 +86,8 @@ async function updatePhoneNumbers(queryRunner: QueryRunner, formatter: (phone: s
   }
 
   // Re-enable triggers on roster.
-  await queryRunner.query(`ALTER TABLE "roster" ENABLE TRIGGER ALL`);
+  await queryRunner.query(`ALTER TABLE "roster" ENABLE TRIGGER "roster_audit"`);
+  await queryRunner.query(`ALTER TABLE "roster" ENABLE TRIGGER "roster_truncate"`);
 
   //
   // Roster history.


### PR DESCRIPTION
Should fix this error when trying to run migrations after deploying...

```
query failed: ALTER TABLE "roster" DISABLE TRIGGER ALL
error: error: permission denied: "RI_ConstraintTrigger_c_20183" is a system trigger
```