### PR TITLE
fix: TypeError: Cannot assign to read only property 'value' of object…

### DIFF
--- a/packages/client/src/components/query-builder/query-builder.tsx
+++ b/packages/client/src/components/query-builder/query-builder.tsx
@@ -117,9 +117,9 @@ const StringValue = ({ onChange, row }: ValueEditorProps) => {
         className={classes.textField}
         onChange={event => {
           // Make a shallow copy to prevent: TypeError: Cannot assign to read only property 'value' of object '#<Object>'
-          const newRow = { ...row };
-          newRow.value = event.target.value;
-          onChange({ ...newRow });
+          const rowShallowCopy = { ...row };
+          rowShallowCopy.value = event.target.value;
+          onChange({ ...rowShallowCopy });
         }}
         placeholder={isExpression === true ? '{{ expression... }}' : row.field.displayName}
         type={row.field.type === QueryFieldType.Number ? 'number' : 'text'}

--- a/packages/client/src/components/query-builder/query-builder.tsx
+++ b/packages/client/src/components/query-builder/query-builder.tsx
@@ -116,8 +116,10 @@ const StringValue = ({ onChange, row }: ValueEditorProps) => {
       <TextField
         className={classes.textField}
         onChange={event => {
-          row.value = event.target.value;
-          onChange({ ...row });
+          // Make a shallow copy to prevent: TypeError: Cannot assign to read only property 'value' of object '#<Object>'
+          const newRow = { ...row };
+          newRow.value = event.target.value;
+          onChange({ ...newRow });
         }}
         placeholder={isExpression === true ? '{{ expression... }}' : row.field.displayName}
         type={row.field.type === QueryFieldType.Number ? 'number' : 'text'}

--- a/packages/client/src/components/query-builder/query-builder.tsx
+++ b/packages/client/src/components/query-builder/query-builder.tsx
@@ -116,10 +116,10 @@ const StringValue = ({ onChange, row }: ValueEditorProps) => {
       <TextField
         className={classes.textField}
         onChange={event => {
-          // Make a shallow copy to prevent: TypeError: Cannot assign to read only property 'value' of object '#<Object>'
-          const rowShallowCopy = { ...row };
-          rowShallowCopy.value = event.target.value;
-          onChange({ ...rowShallowCopy });
+          onChange({
+            ...row,
+            value: event.target.value,
+          });
         }}
         placeholder={isExpression === true ? '{{ expression... }}' : row.field.displayName}
         type={row.field.type === QueryFieldType.Number ? 'number' : 'text'}

--- a/packages/server/src/api/report-schema/report-schema.controller.ts
+++ b/packages/server/src/api/report-schema/report-schema.controller.ts
@@ -49,17 +49,17 @@ class ReportSchemaController {
   }
 
   async getReport(req: ApiRequest<OrgReportParams>, res: Response) {
-    res.json(await ReportSchemaController.findReport(req));
+    res.json(await findReport(req.appOrg!.id, req.params.reportId));
   }
 
   async deleteReport(req: ApiRequest<OrgReportParams>, res: Response) {
-    const report = await ReportSchemaController.findReport(req);
+    const report = await findReport(req.appOrg!.id, req.params.reportId);
     const removedReport = await report.remove();
     res.json(removedReport);
   }
 
   async updateReport(req: ApiRequest<OrgReportParams, UpdateReportBody>, res: Response) {
-    const report = await ReportSchemaController.findReport(req);
+    const report = await findReport(req.appOrg!.id, req.params.reportId);
 
     if (req.body.name != null) {
       report.name = req.body.name;
@@ -74,18 +74,16 @@ class ReportSchemaController {
     res.json(updatedReport);
   }
 
-  private static async findReport(req: ApiRequest<OrgReportParams>) {
-    const id = req.params.reportId;
-    const org = req.appOrg!.id;
-    const report = await ReportSchema.findOne({ relations: ['org'], where: { id, org } });
+}
 
-    if (!report) {
-      Log.error(`report_schema table is missing a record for ID ${id} and org ID ${org} `);
-      throw new NotFoundError('Report could not be found.');
-    }
-    return report;
+async function findReport(orgId: number, reportId: string) {
+  const report = await ReportSchema.findOne({ relations: ['org'], where: { id: reportId, org: orgId } });
+
+  if (!report) {
+    Log.error(`report_schema table is missing a record for ID ${orgId} and org ID ${reportId} `);
+    throw new NotFoundError('Report could not be found.');
   }
-
+  return report;
 }
 
 export type AddReportBody = {


### PR DESCRIPTION
1. Fix - TypeError: Cannot assign to read only property 'value' of object '#<Object>': https://app.asana.com/0/1188940305683068/1200699481497258
I am not sure what made 'value' to be read only but creating a shallow copy of the row object fixed the issue. 


2. Simplify troubleshooting of errors from /api/report/: https://app.asana.com/0/1188940305683068/1200699481497260/f
