### PR TITLE
Switch all eslint rules to only cause warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-mocha-no-only": "^1.1.1",
+    "eslint-plugin-only-warn": "^1.0.3",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -15,10 +15,11 @@
     "@typescript-eslint",
     "import",
     "chai-friendly",
-    "mocha-no-only"
+    "mocha-no-only",
+    "only-warn"
   ],
   "rules": {
-    "@typescript-eslint/type-annotation-spacing": ["error", {
+    "@typescript-eslint/type-annotation-spacing": ["warn", {
       "overrides" : {
         "colon": {
           "before": false,
@@ -27,46 +28,46 @@
       }
     }],
     "@typescript-eslint/lines-between-class-members": "off",
-    "@typescript-eslint/member-delimiter-style": "error",
-    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/member-delimiter-style": "warn",
+    "@typescript-eslint/no-floating-promises": "warn",
     "@typescript-eslint/no-unused-expressions": "off",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/object-curly-spacing": "off",
-    "@typescript-eslint/quotes": ["error", "single", { "allowTemplateLiterals": true }],
+    "@typescript-eslint/quotes": ["warn", "single", { "allowTemplateLiterals": true }],
     "@typescript-eslint/return-await": "off",
-    "@typescript-eslint/space-before-function-paren": ["error", {
+    "@typescript-eslint/space-before-function-paren": ["warn", {
       "anonymous": "never",
       "named": "never",
       "asyncArrow": "always"
     }],
     "arrow-body-style": "off",
-    "arrow-parens": ["error", "as-needed", { "requireForBlockBody": false }],
-    "chai-friendly/no-unused-expressions": ["error", { "allowShortCircuit": true }],
+    "arrow-parens": ["warn", "as-needed", { "requireForBlockBody": false }],
+    "chai-friendly/no-unused-expressions": ["warn", { "allowShortCircuit": true }],
     "class-methods-use-this": "off",
-    "curly": ["error", "all"],
+    "curly": ["warn", "all"],
     "func-names": "off",
     "global-require": "off",
     "import/no-cycle": "off",
     "import/no-dynamic-require": "off",
     "import/prefer-default-export": "off",
-    "key-spacing": ["error", {
+    "key-spacing": ["warn", {
       "beforeColon": false,
       "afterColon": true
     }],
     "max-classes-per-file": "off",
     "max-len": "off",
-    "mocha-no-only/mocha-no-only": "error",
+    "mocha-no-only/mocha-no-only": "warn",
     "no-await-in-loop": "off",
     "no-console": "off",
     "no-continue": "off",
-    "no-empty": ["error", { "allowEmptyCatch":  true }],
-    "no-multiple-empty-lines": ["error", { "max": 2, "maxBOF": 0, "maxEOF": 1 }],
+    "no-empty": ["warn", { "allowEmptyCatch":  true }],
+    "no-multiple-empty-lines": ["warn", { "max": 2, "maxBOF": 0, "maxEOF": 1 }],
     "no-nested-ternary": "off",
     "no-param-reassign": "off",
-    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
+    "no-plusplus": ["warn", { "allowForLoopAfterthoughts": true }],
     "no-prototype-builtins": "off",
     "no-restricted-syntax": [
-      "error",
+      "warn",
       {
         "selector": "ForInStatement",
         "message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
@@ -85,19 +86,19 @@
     "no-unused-expressions": "off",
     "no-use-before-define": "off",
     "no-void": "off",
-    "object-curly-newline": ["error", { "consistent": true }],
-    "object-curly-spacing": ["error", "always"],
-    "padded-blocks": ["error", {
+    "object-curly-newline": ["warn", { "consistent": true }],
+    "object-curly-spacing": ["warn", "always"],
+    "padded-blocks": ["warn", {
       "blocks": "never",
       "classes": "always",
       "switches": "never"
     }],
     "prefer-destructuring": "off",
-    "promise/prefer-await-to-then": ["error", "always"],
-    "promise/prefer-await-to-callbacks": ["error", "always"],
+    "promise/prefer-await-to-then": ["warn", "always"],
+    "promise/prefer-await-to-callbacks": ["warn", "always"],
     "radix": "off",
-    "require-await": "error",
-    "space-before-function-paren": ["error", {
+    "require-await": "warn",
+    "space-before-function-paren": ["warn", {
       "anonymous": "never",
       "named": "never",
       "asyncArrow": "always"

--- a/packages/client/.eslintrc.json
+++ b/packages/client/.eslintrc.json
@@ -11,7 +11,8 @@
     "react-hooks",
     "import",
     "chai-friendly",
-    "mocha-no-only"
+    "mocha-no-only",
+    "only-warn"
   ],
   "rules": {
     "jsx-a11y/label-has-associated-control": "off",

--- a/packages/client/.eslintrc.json
+++ b/packages/client/.eslintrc.json
@@ -20,7 +20,7 @@
     "react/jsx-props-no-spreading": "off",
     "react/no-array-index-key": "off",
     "react/require-default-props": "off",
-    "react-hooks/exhaustive-deps": ["error", {
+    "react-hooks/exhaustive-deps": ["warn", {
       "additionalHooks": "useEffectDebounced"
     }]
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -77,6 +77,7 @@
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-mocha-no-only": "^1.1.1",
+    "eslint-plugin-only-warn": "^1.0.3",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "chai": "^4.3.4",
     "eslint": "^7.29.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-typescript": "^12.3.1",

--- a/packages/shared/src/utils/days.spec.ts
+++ b/packages/shared/src/utils/days.spec.ts
@@ -1,5 +1,5 @@
-import {expect} from 'chai';
-import { binaryDaysToDateArray, DaysOfTheWeek, nextDay, dayIsIn } from './days';
+import { expect } from 'chai';
+import { binaryDaysToDateArray, DaysOfTheWeek, nextDay } from './days';
 
 describe('days', () => {
   describe('binaryDaysToDateArray()', () => {
@@ -25,11 +25,11 @@ describe('days', () => {
       expect(binaryDaysToDateArray(DaysOfTheWeek.Saturday)).to.eql([7]);
     });
     it('expect to return 2nd and 7th day of the week', () => {
-    // eslint-disable-next-line no-bitwise
+      // eslint-disable-next-line no-bitwise
       expect(binaryDaysToDateArray(DaysOfTheWeek.Saturday | DaysOfTheWeek.Monday)).to.eql([2, 7]);
     });
     it('expect to return all day of the week', () => {
-    // eslint-disable-next-line no-bitwise
+      // eslint-disable-next-line no-bitwise
       expect(binaryDaysToDateArray(DaysOfTheWeek.Sunday | DaysOfTheWeek.Monday | DaysOfTheWeek.Tuesday | DaysOfTheWeek.Wednesday
       | DaysOfTheWeek.Thursday | DaysOfTheWeek.Friday | DaysOfTheWeek.Saturday)).to.eql([1, 2, 3, 4, 5, 6, 7]);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4240,7 +4240,7 @@ chai-subset@^1.6.0:
   resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"
   integrity sha1-pdDKFOMpp5WW7XAFi2ZGvWmIz+k=
 
-chai@^4.2.0:
+chai@^4.2.0, chai@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
   integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==
@@ -6375,6 +6375,11 @@ eslint-plugin-mocha-no-only@^1.1.1:
   integrity sha512-b+vgjJQ3SjRQCygBhomtjzvRQRpIP8Yd9cqwNSbcoVJREuNajao7M1Kl1aObAUc4wx98qsZyQyUSUxiAbMS9yA==
   dependencies:
     requireindex "~1.1.0"
+
+eslint-plugin-only-warn@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.0.3.tgz#a75f3a9ded7f03e9808e75ec27f22b644084506e"
+  integrity sha512-XQOX/TfLoLw6h8ky51d29uUjXRTQHqBGXPylDEmy5fe/w7LIOnp8MA24b1OSMEn9BQoKow1q3g1kLe5/9uBTvw==
 
 eslint-plugin-promise@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
After a recent change, compilation started failing any time there were any eslint issues, which caused some very annoying workflow issues. This change should make sure compilation always succeeds while still pointing out eslint issues.