### PR TITLE
Fix "disableBackdropClick" deprecation warnings in frontend.

### DIFF
--- a/packages/client/src/components/dialog/dialog.tsx
+++ b/packages/client/src/components/dialog/dialog.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {
+  Dialog as MuiDialog,
+  DialogProps,
+} from '@material-ui/core';
+
+/**
+ * Wrapper for Material UI Dialog class to allow us to set default behavior for
+ * onClose().
+ */
+export const Dialog = (props: DialogProps) => {
+  const { onClose, children, ...otherProps } = props;
+
+  const handleClose = (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => {
+    if (reason !== 'backdropClick') {
+      if (onClose) {
+        onClose(event, reason);
+      }
+    }
+  };
+
+  return (
+    <MuiDialog
+      {...otherProps}
+      onClose={handleClose}
+    >
+      {children}
+    </MuiDialog>
+  );
+};

--- a/packages/client/src/components/help/help-button/help-button.tsx
+++ b/packages/client/src/components/help/help-button/help-button.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -13,6 +12,7 @@ import React, {
   useState,
 } from 'react';
 import { HelpContent } from '../help-content/help-content';
+import { Dialog } from '../../dialog/dialog';
 
 export interface HelpButtonProps {
   title: string;

--- a/packages/client/src/components/modal/modal.tsx
+++ b/packages/client/src/components/modal/modal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -12,6 +11,7 @@ import { ModalButton } from '../../reducers/modal.reducer';
 import useStyles from './modal.styles';
 import { useAppDispatch } from '../../hooks/use-app-dispatch';
 import { useAppSelector } from '../../hooks/use-app-selector';
+import { Dialog } from '../dialog/dialog';
 
 const defaultButtons: ModalButton[] = [
   { text: 'Ok' },

--- a/packages/client/src/components/pages/edit-spaces-page/edit-space-dialog.tsx
+++ b/packages/client/src/components/pages/edit-spaces-page/edit-space-dialog.tsx
@@ -1,17 +1,24 @@
 import React, { useState } from 'react';
 import {
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  Grid, Select, Table, TableBody, TableCell, TableRow, TextField, Typography,
+  Grid,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  TextField,
+  Typography,
 } from '@material-ui/core';
 import CheckIcon from '@material-ui/icons/Check';
 import useStyles from './edit-space-dialog.styles';
 import { ApiWorkspace, ApiWorkspaceTemplate } from '../../../models/api-response';
 import { formatErrorMessage } from '../../../utility/errors';
 import { WorkspaceClient } from '../../../client/workspace.client';
+import { Dialog } from '../../dialog/dialog';
 
 export interface EditWorkspaceDialogProps {
   open: boolean;

--- a/packages/client/src/components/pages/edit-spaces-page/edit-spaces-page.tsx
+++ b/packages/client/src/components/pages/edit-spaces-page/edit-spaces-page.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Container,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -42,6 +41,7 @@ import { EditSpacesPageHelp } from './edit-spaces-page-help';
 import { WorkspaceClient } from '../../../client/workspace.client';
 import { useAppDispatch } from '../../../hooks/use-app-dispatch';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 interface WorkspaceMenuState {
   anchor: HTMLElement | null;

--- a/packages/client/src/components/pages/groups-page/request-access-dialog.tsx
+++ b/packages/client/src/components/pages/groups-page/request-access-dialog.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Button,
   Checkbox,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogProps,
@@ -31,6 +30,7 @@ import {
 import { ButtonWithSpinner } from '../../buttons/button-with-spinner';
 import useStyles from './request-access-dialog.styles';
 import { AccessRequestClient } from '../../../client/access-request.client';
+import { Dialog } from '../../dialog/dialog';
 
 export type RequestAccessDialogProps = DialogProps & {
   onClose: () => void;
@@ -362,7 +362,6 @@ export const RequestAccessDialog = (props: RequestAccessDialogProps) => {
         open={open}
         onClose={onClose}
         onExited={reset}
-        disableBackdropClick
       >
         <DialogContent>
           <Box component="p" marginTop={0}>

--- a/packages/client/src/components/pages/role-management-page/edit-role-dialog.tsx
+++ b/packages/client/src/components/pages/role-management-page/edit-role-dialog.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Button,
   Checkbox,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -34,6 +33,7 @@ import { WorkspaceSelector } from '../../../selectors/workspace.selector';
 import { formatErrorMessage } from '../../../utility/errors';
 import { RoleClient } from '../../../client/role.client';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 export interface EditRoleDialogProps {
   open: boolean;

--- a/packages/client/src/components/pages/role-management-page/role-management-page.tsx
+++ b/packages/client/src/components/pages/role-management-page/role-management-page.tsx
@@ -5,7 +5,6 @@ import {
   AccordionSummary,
   Button,
   Container,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -38,6 +37,7 @@ import { RoleClient } from '../../../client/role.client';
 import { AppFrameActions } from '../../../slices/app-frame.slice';
 import { useAppDispatch } from '../../../hooks/use-app-dispatch';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 export const RoleManagementPage = () => {
   const classes = useStyles();

--- a/packages/client/src/components/pages/roster-columns-page/edit-column-dialog.tsx
+++ b/packages/client/src/components/pages/roster-columns-page/edit-column-dialog.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   Button,
   Checkbox,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -34,6 +33,7 @@ import {
 import { EditableBooleanTable } from '../../tables/editable-boolean-table';
 import { formatErrorMessage } from '../../../utility/errors';
 import { RosterClient } from '../../../client/roster.client';
+import { Dialog } from '../../dialog/dialog';
 
 export interface EditColumnDialogProps {
   open: boolean;

--- a/packages/client/src/components/pages/roster-columns-page/roster-columns-page.tsx
+++ b/packages/client/src/components/pages/roster-columns-page/roster-columns-page.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Container,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -36,6 +35,7 @@ import { RosterClient } from '../../../client/roster.client';
 import { AppFrameActions } from '../../../slices/app-frame.slice';
 import { useAppDispatch } from '../../../hooks/use-app-dispatch';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 interface ColumnMenuState {
   anchor: HTMLElement | null;

--- a/packages/client/src/components/pages/roster-page/edit-roster-entry-dialog.tsx
+++ b/packages/client/src/components/pages/roster-page/edit-roster-entry-dialog.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Button,
   Checkbox,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -37,6 +36,7 @@ import { UnitSelector } from '../../../selectors/unit.selector';
 import { formatErrorMessage } from '../../../utility/errors';
 import { RosterClient } from '../../../client/roster.client';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 export interface EditRosterEntryDialogProps {
   open: boolean;

--- a/packages/client/src/components/pages/roster-page/save-new-filter-dialog.tsx
+++ b/packages/client/src/components/pages/roster-page/save-new-filter-dialog.tsx
@@ -4,7 +4,6 @@ import React, {
 } from 'react';
 import {
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -13,6 +12,7 @@ import {
   TextField,
 } from '@material-ui/core';
 import { ButtonWithSpinner } from '../../buttons/button-with-spinner';
+import { Dialog } from '../../dialog/dialog';
 
 export interface SaveNewFilterDialogProps {
   open: boolean;

--- a/packages/client/src/components/pages/settings-page/edit-alert-dialog.tsx
+++ b/packages/client/src/components/pages/settings-page/edit-alert-dialog.tsx
@@ -1,11 +1,15 @@
 import React, { useState } from 'react';
 import {
-  Button, Checkbox,
-  Dialog,
+  Button,
+  Checkbox,
   DialogActions,
   DialogContent,
-  DialogTitle, FormControlLabel,
-  Grid, Paper, TextField, Typography,
+  DialogTitle,
+  FormControlLabel,
+  Grid,
+  Paper,
+  TextField,
+  Typography,
 } from '@material-ui/core';
 import useStyles from './edit-alert-dialog.styles';
 import {
@@ -16,6 +20,7 @@ import { ButtonWithSpinner } from '../../buttons/button-with-spinner';
 import { buildSettingText } from './notifications-tab';
 import { formatErrorMessage } from '../../../utility/errors';
 import { NotificationClient } from '../../../client/notification.client';
+import { Dialog } from '../../dialog/dialog';
 
 export interface EditAlertDialogProps {
   open: boolean;

--- a/packages/client/src/components/pages/units-page/default-muster-dialog.tsx
+++ b/packages/client/src/components/pages/units-page/default-muster-dialog.tsx
@@ -3,7 +3,6 @@ import {
   Avatar,
   Box,
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -41,6 +40,7 @@ import { ReportSchemaSelector } from '../../../selectors/report-schema.selector'
 import { formatErrorMessage } from '../../../utility/errors';
 import { OrgClient } from '../../../client/org.client';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 export interface DefaultMusterDialogProps {
   open: boolean;

--- a/packages/client/src/components/pages/units-page/edit-unit-dialog.tsx
+++ b/packages/client/src/components/pages/units-page/edit-unit-dialog.tsx
@@ -7,7 +7,6 @@ import {
   Avatar,
   Button,
   Checkbox,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -53,6 +52,7 @@ import {
 } from '../../../utility/muster-utils';
 import { UnitClient } from '../../../client/unit.client';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 export interface EditUnitDialogProps {
   open: boolean;

--- a/packages/client/src/components/pages/units-page/units-page.tsx
+++ b/packages/client/src/components/pages/units-page/units-page.tsx
@@ -5,7 +5,6 @@ import {
   CardContent,
   CardHeader,
   Container,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -54,6 +53,7 @@ import { UnitClient } from '../../../client/unit.client';
 import { useAppDispatch } from '../../../hooks/use-app-dispatch';
 import { UserActions } from '../../../slices/user.slice';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 interface UnitMenuState {
   anchor: HTMLElement | null;

--- a/packages/client/src/components/pages/users-page/select-role-dialog.tsx
+++ b/packages/client/src/components/pages/users-page/select-role-dialog.tsx
@@ -5,7 +5,6 @@ import React, {
 import {
   Button,
   Checkbox,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -32,6 +31,7 @@ import { Roster } from '../../../actions/roster.actions';
 import RoleInfoPanel from '../../role-info-panel/role-info-panel';
 import { useAppDispatch } from '../../../hooks/use-app-dispatch';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 export type SelectRoleDialogProps = {
   confirmButtonText: string;

--- a/packages/client/src/components/pages/users-page/users-page.tsx
+++ b/packages/client/src/components/pages/users-page/users-page.tsx
@@ -11,7 +11,6 @@ import {
   TableHead,
   TableRow,
   DialogActions,
-  Dialog,
   DialogContent,
   DialogContentText,
   IconButton,
@@ -37,6 +36,7 @@ import { UserClient } from '../../../client/user.client';
 import { AppFrameActions } from '../../../slices/app-frame.slice';
 import { useAppDispatch } from '../../../hooks/use-app-dispatch';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 type UserMoreMenuState = {
   element: HTMLElement;

--- a/packages/client/src/components/pages/users-page/view-access-request-dialog.tsx
+++ b/packages/client/src/components/pages/users-page/view-access-request-dialog.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Button,
   Checkbox,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogProps,
@@ -41,6 +40,7 @@ import useStyles from './view-access-request-dialog.styles';
 import { AccessRequestClient } from '../../../client/access-request.client';
 import { useAppDispatch } from '../../../hooks/use-app-dispatch';
 import { useAppSelector } from '../../../hooks/use-app-selector';
+import { Dialog } from '../../dialog/dialog';
 
 export type ViewAccessRequestDialogProps = DialogProps & {
   onClose: () => void;

--- a/packages/client/src/theme.ts
+++ b/packages/client/src/theme.ts
@@ -245,9 +245,6 @@ theme.props = {
   MuiCheckbox: {
     color: 'primary',
   },
-  MuiDialog: {
-    disableBackdropClick: true,
-  },
   MuiIconButton: {
     color: 'primary',
   },


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200665371881023

This was starting to cause workflow issues with these warnings spamming the console, so I went ahead and fixed the problem.

Material UI no longer accepts a `disableBackdropClick` bool, and now forces you to handle it yourself in the `onClose` callback. Since there's no way to set a default for it in the theme anymore, and it would be a pain to have to handle this everywhere, I wrapped the Material UI Dialog component and disabled closing on backdrop click by default.