### PR TITLE
Hide modal non-serializable redux warnings.

### DIFF
--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -58,6 +58,7 @@ import {
   localStorageInitialState,
   localStorageSlice,
 } from './slices/local-storage.slice';
+import { Modal } from './actions/modal.actions';
 
 const initialState = {
   appFrame: appFrameInitialState,
@@ -106,7 +107,9 @@ export const store = configureStore({
   middleware: getDefaultMiddleware => {
     return getDefaultMiddleware({
       serializableCheck: {
-        ignoredActions: persistActions,
+        ignoredActions: persistActions.concat([
+          Modal.Actions.Alert.type,
+        ]),
       },
     }).concat(middleware);
   },


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200798997647512

This warning is almost certainly an indication of an anti-pattern here, and we should probably revisit the way our modals are built at some point. But for now we should be safe just hiding the warnings so that we can keep the console clean.