### PR TITLE
added return codes to build scripts to abort on failure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,13 +6,13 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 mkdir build
 
 # Server
-yarn run server build
+yarn run server build || exit 1
 
 mv ./packages/server/build/* ./build
 rmdir ./packages/server/build
 
 # Client
-yarn run client build
+yarn run client build || exit 1
 
 mv ./packages/client/build/* ./build
 rmdir ./packages/client/build

--- a/packages/client/build.sh
+++ b/packages/client/build.sh
@@ -5,7 +5,7 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 echo -e "\nBuilding client..."
 
 ./clean.sh
-npx craco build
+npx craco build || exit 1
 mkdir ./build/public
 mv ./build/*.* ./build/public
 mv ./build/static ./build/public/static

--- a/packages/server/build.sh
+++ b/packages/server/build.sh
@@ -5,6 +5,6 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 echo -e "\nBuilding server..."
 
 ./clean.sh
-tsc -b tsconfig.build.json
+tsc -b tsconfig.build.json || exit 1
 
 echo -e "Server build complete!\n"

--- a/packages/shared/build.sh
+++ b/packages/shared/build.sh
@@ -5,6 +5,6 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 echo -e "\nBuilding shared..."
 
 ./clean.sh
-tsc -b tsconfig.build.json
+tsc -b tsconfig.build.json || exit 1
 
 echo "Shared build complete!"


### PR DESCRIPTION
Build failures were silently passing in Jenkins and causing bad covid19-reports images to be created.  I've added exit codes on failures for server, client, shared as well as the top level build.sh scripts to catch these failures.