### PR TITLE
Fix exceptions when using expressions in query builder.

### DIFF
--- a/packages/client/src/components/query-builder/query-builder-value-editor.tsx
+++ b/packages/client/src/components/query-builder/query-builder-value-editor.tsx
@@ -1,4 +1,5 @@
 import React, {
+  ReactElement,
   useEffect,
   useMemo,
 } from 'react';
@@ -32,15 +33,15 @@ import {
 const expressionFieldPlaceholder = 'Expression';
 const expressionCheckboxTooltip = 'Use Expression';
 
-export interface QueryBuilderRowValueProps {
+export type QueryBuilderValueEditorProps = {
   onChange: (row: QueryRow) => void;
   row: QueryRow;
-}
+};
 
-export const QueryBuilderValueEditor = (props: QueryBuilderRowValueProps) => {
+export const QueryBuilderValueEditor = (props: QueryBuilderValueEditorProps) => {
   const { row } = props;
 
-  let editor: React.ReactElement<QueryBuilderRowValueProps>;
+  let editor: React.ReactElement<QueryBuilderValueEditorProps>;
 
   switch (row.field.type) {
     case ColumnType.Date:
@@ -66,7 +67,7 @@ export const QueryBuilderValueEditor = (props: QueryBuilderRowValueProps) => {
   return editor;
 };
 
-const QueryBuilderStringEditor = ({ onChange, row }: QueryBuilderRowValueProps) => {
+const QueryBuilderStringEditor = ({ onChange, row }: QueryBuilderValueEditorProps) => {
   const classes = useStyles();
 
   const isExpressionValid = useMemo(() => {
@@ -140,7 +141,7 @@ const QueryBuilderStringEditor = ({ onChange, row }: QueryBuilderRowValueProps) 
   );
 };
 
-const QueryBuilderBooleanEditor = ({ onChange, row }: QueryBuilderRowValueProps) => {
+const QueryBuilderBooleanEditor = ({ onChange, row }: QueryBuilderValueEditorProps) => {
   return (
     <Switch
       checked={Boolean(row.value)}
@@ -156,11 +157,11 @@ const QueryBuilderBooleanEditor = ({ onChange, row }: QueryBuilderRowValueProps)
   );
 };
 
-interface DateTimeValueEditorProps extends QueryBuilderRowValueProps {
+type QueryBuilderDateTimeEditorProps = QueryBuilderValueEditorProps & {
   hasTime: boolean;
-}
+};
 
-const QueryBuilderDateTimeEditor = ({ hasTime, onChange, row }: DateTimeValueEditorProps) => {
+const QueryBuilderDateTimeEditor = ({ hasTime, onChange, row }: QueryBuilderDateTimeEditorProps) => {
   const classes = useStyles();
 
   const isExpressionValid = useMemo(() => {
@@ -259,9 +260,9 @@ const QueryBuilderDateTimeEditor = ({ hasTime, onChange, row }: DateTimeValueEdi
   );
 };
 
-interface QueryBuilderValueRangeEditorProps extends QueryBuilderRowValueProps {
-  editorComponent: React.ReactElement<QueryBuilderRowValueProps>;
-}
+type QueryBuilderValueRangeEditorProps = QueryBuilderValueEditorProps & {
+  editorComponent: ReactElement<QueryBuilderValueEditorProps>;
+};
 
 const QueryBuilderValueRangeEditor = ({ editorComponent, onChange, row }: QueryBuilderValueRangeEditorProps) => {
   const range = useMemo(() => {
@@ -304,7 +305,7 @@ const QueryBuilderValueRangeEditor = ({ editorComponent, onChange, row }: QueryB
   );
 };
 
-const QueryBuilderEnumEditor = (props: QueryBuilderRowValueProps) => {
+const QueryBuilderEnumEditor = (props: QueryBuilderValueEditorProps) => {
   const classes = useStyles();
 
   const { onChange, row } = props;

--- a/packages/client/src/components/query-builder/query-builder.styles.ts
+++ b/packages/client/src/components/query-builder/query-builder.styles.ts
@@ -31,4 +31,7 @@ export default makeStyles((theme: Theme) => createStyles({
   pickListSelect: {
     minWidth: '193px',
   },
+  tooltipMultiline: {
+    whiteSpace: 'pre-line',
+  },
 }));

--- a/packages/client/src/utility/query-builder-utils.ts
+++ b/packages/client/src/utility/query-builder-utils.ts
@@ -146,3 +146,51 @@ export function filterConfigToQueryRows(filterConfig: FilterConfig, fields: Quer
       field,
     }));
 }
+
+export function isValidMathExpression(expression: string) {
+  const regex = /^([-+/*]\d+(\.\d+)?)*/;
+  return regex.test(expression);
+}
+
+export function evalMathExpression(expression: string) {
+  if (!isValidMathExpression(expression)) {
+    return {
+      isValid: false,
+      value: NaN,
+    };
+  }
+
+  let isValid: boolean;
+  let value: number;
+  try {
+    // eslint-disable-next-line no-eval
+    value = eval(expression);
+    isValid = true;
+  } catch (err) {
+    value = NaN;
+    isValid = false;
+  }
+
+  return { isValid, value };
+}
+
+export function evalDateExpression(expression: string) {
+  let isValid: boolean;
+  let value: string;
+  try {
+    const jsonValue = JSON.parse(expression);
+    value = moment().startOf('day').add(jsonValue).toISOString();
+    isValid = true;
+  } catch (e) {
+    value = '';
+    isValid = false;
+  }
+
+  return { isValid, value };
+}
+
+export function getExpressionHelperText(row: QueryRow, isExpressionValid: boolean) {
+  return (row.expression && !isExpressionValid)
+    ? 'Invalid expression'
+    : row.value;
+}


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200890989194653

Expressions should work as expected now in the query builder without any errors. I guess this code must have gotten rushed through, since it really shouldn't have been approved with those direct state mutations (which are essentially illegal in React).

It may seem like a lot of changed lines to fix that bug, but there were mutations happening in lots of places. So most, if not all, of the components in this file had to be reworked to some degree, and I did some cleanup in some places while I was at it.

I also extracted out some utility functions to try and make the code a little easier to follow. It would be really nice to move each of these components to their own file as well, but I'm resisting the urge since I know large PRs have been a nuisance lately. Maybe we can break things out to their own files all in one pass so that it doesn't get intermingled with actual changes.

In the future I'm thinking a couple things to look out for in reviews should be any sorts of mutations happening in React components, as well as having lots of components in one file. Both of those should get flagged for sure before we approve a PR.