### PR TITLE
Fix errors when using 'between' in filters.

### DIFF
--- a/packages/client/src/utility/query-builder-utils.ts
+++ b/packages/client/src/utility/query-builder-utils.ts
@@ -121,7 +121,10 @@ export function opRequiresValue(op: QueryOp) {
  */
 export function queryRowsToFilterConfig(queryRows: QueryRow[]): FilterConfig {
   const config: FilterConfig = {};
-  const validQueryRows = queryRows.filter(row => row.field && !opRequiresValue(row.op) || (row.value !== null && row.value !== undefined));
+  const validQueryRows = queryRows.filter(row => (
+    (row.field && !opRequiresValue(row.op))
+    || (row.value !== null && row.value !== undefined)
+  ));
 
   for (const row of validQueryRows) {
     let value = row.value;
@@ -139,7 +142,11 @@ export function queryRowsToFilterConfig(queryRows: QueryRow[]): FilterConfig {
       value = listValues;
     }
 
-    config[row.field.table ? `${row.field.table}.${row.field.name}` : row.field.name] = {
+    const columnName = row.field.table
+      ? `${row.field.table}.${row.field.name}`
+      : row.field.name;
+
+    config[columnName] = {
       op: row.op,
       expression: row.expression ?? '',
       expressionEnabled: row.expressionEnabled ?? false,


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200983953900253

This was an issue where the row value needed to be converted into an array for the range value editor. I went ahead and cleaned up the range value editor a bit as well since it was pretty difficult to understand.

Query rows currently only support a single expression per row, so I disabled expressions for range filters for now. 