### PR TITLE
Restart server locally when shared files change.

### DIFF
--- a/packages/server/nodemon.json
+++ b/packages/server/nodemon.json
@@ -1,6 +1,6 @@
 {
   "ignore": ["**/*.test.ts", "**/*.spec.ts", ".git", "node_modules"],
-  "watch": ["./"],
+  "watch": ["./", "../shared"],
   "exec": "./node.sh --inspect=127.0.0.1:9229 ./src/index.ts",
   "ext": "ts"
 }


### PR DESCRIPTION
Quick fix that may save people some confusion. The server wasn't automatically restarting when modifying shared project files, which could make it look like your changes didn't work.

This is probably an issue for the client as well, but that will require a bit more digging to figure out how to customize craco to watch the shared project.