### PR TITLE
Filter and layout permissions.

### DIFF
--- a/packages/client/src/components/query-builder/query-builder-field-select.tsx
+++ b/packages/client/src/components/query-builder/query-builder-field-select.tsx
@@ -6,10 +6,11 @@ import { QueryField } from '../../utility/query-builder-utils';
 type QueryBuilderFieldSelectProps = {
   fields: QueryField[];
   onChange: (field: QueryField) => void;
+  disabled?: boolean;
 };
 
 export const QueryBuilderFieldSelect = (props: QueryBuilderFieldSelectProps) => {
-  const { fields, onChange } = props;
+  const { fields, onChange, disabled } = props;
   return (
     <Select
       native
@@ -18,6 +19,7 @@ export const QueryBuilderFieldSelect = (props: QueryBuilderFieldSelectProps) => 
       onChange={event => {
         onChange(fields[event.target.value as number]);
       }}
+      disabled={disabled}
     >
       {fields.map((field, index) => (
         <option key={getFullyQualifiedColumnName(field)} value={index}>

--- a/packages/client/src/components/query-builder/query-builder-op-select.tsx
+++ b/packages/client/src/components/query-builder/query-builder-op-select.tsx
@@ -7,10 +7,11 @@ type QueryBuilderOpSelectProps = {
   onChange: (op: QueryOp) => void;
   value: QueryOp;
   ops: QueryOpsDesc;
+  disabled?: boolean;
 };
 
 export const QueryBuilderOpSelect = (props: QueryBuilderOpSelectProps) => {
-  const { onChange, ops, value } = props;
+  const { onChange, ops, value, disabled } = props;
   return (
     <Select
       native
@@ -20,6 +21,7 @@ export const QueryBuilderOpSelect = (props: QueryBuilderOpSelectProps) => {
       onChange={event => {
         onChange(event.target.value as QueryOp);
       }}
+      disabled={disabled}
     >
       {Object.entries(ops).map(([key, label]) => (
         <option key={key} value={key}>

--- a/packages/client/src/components/query-builder/query-builder-row.tsx
+++ b/packages/client/src/components/query-builder/query-builder-row.tsx
@@ -29,10 +29,11 @@ export type QueryBuilderRowProps = {
   onRemoveClick: (row: QueryRow) => void;
   row: QueryRow;
   expressionRefsByType?: Map<QueryValueType, ExpressionReference[]>;
+  disabled?: boolean;
 };
 
 export const QueryBuilderRow = (props: QueryBuilderRowProps) => {
-  const { availableFields, onChange, onRemoveClick, row, expressionRefsByType } = props;
+  const { availableFields, onChange, onRemoveClick, row, expressionRefsByType, disabled } = props;
 
   const classes = useStyles();
   const ops = getFieldQueryOpDesc(row.field);
@@ -77,6 +78,7 @@ export const QueryBuilderRow = (props: QueryBuilderRowProps) => {
               expressionEnabled: false,
             });
           }}
+          disabled={disabled}
         />
       </Grid>
 
@@ -94,20 +96,28 @@ export const QueryBuilderRow = (props: QueryBuilderRowProps) => {
             }}
             ops={ops}
             value={row.op}
+            disabled={disabled}
           />
         </Grid>
       )}
 
       <Grid item>
-        <QueryBuilderValueEditor onChange={onChange} row={row} expressionRefsByType={expressionRefsByType} />
+        <QueryBuilderValueEditor
+          onChange={onChange}
+          row={row}
+          expressionRefsByType={expressionRefsByType}
+          disabled={disabled}
+        />
       </Grid>
 
-      <IconButton
-        className={classes.removeRowButton}
-        onClick={handleRemoveClick}
-      >
-        <HighlightOffIcon />
-      </IconButton>
+      {!disabled && (
+        <IconButton
+          className={classes.removeRowButton}
+          onClick={handleRemoveClick}
+        >
+          <HighlightOffIcon />
+        </IconButton>
+      )}
     </>
   );
 };

--- a/packages/client/src/components/query-builder/query-builder-value-editor.tsx
+++ b/packages/client/src/components/query-builder/query-builder-value-editor.tsx
@@ -45,6 +45,7 @@ export type QueryBuilderValueEditorProps = {
   onChange: (row: QueryRow) => void;
   row: QueryRow;
   expressionRefsByType?: Map<QueryValueType, ExpressionReference[]>;
+  disabled?: boolean;
 };
 
 export const QueryBuilderValueEditor = (props: QueryBuilderValueEditorProps) => {
@@ -80,7 +81,7 @@ export const QueryBuilderValueEditor = (props: QueryBuilderValueEditorProps) => 
   return editor;
 };
 
-const QueryBuilderStringEditor = ({ onChange, row }: QueryBuilderValueEditorProps) => {
+const QueryBuilderStringEditor = ({ onChange, row, disabled }: QueryBuilderValueEditorProps) => {
   const classes = useStyles();
 
   const isExpressionValid = useMemo(() => {
@@ -101,6 +102,7 @@ const QueryBuilderStringEditor = ({ onChange, row }: QueryBuilderValueEditorProp
         placeholder={row.field.displayName}
         type={row.field.type === ColumnType.Number ? 'number' : 'text'}
         value={row.value}
+        disabled={disabled}
       />
     );
   };
@@ -134,6 +136,7 @@ const QueryBuilderStringEditor = ({ onChange, row }: QueryBuilderValueEditorProp
           error={!isExpressionValid}
           helperText={getExpressionHelperText(row, isExpressionValid)}
           placeholder={expressionFieldPlaceholder}
+          disabled={disabled}
         />
       </Tooltip>
     );
@@ -147,6 +150,7 @@ const QueryBuilderStringEditor = ({ onChange, row }: QueryBuilderValueEditorProp
           <Checkbox
             value={row.expressionEnabled}
             onChange={event => handleUseExpressionChange(event.target.checked)}
+            disabled={disabled}
           />
         </Tooltip>
       )}
@@ -154,7 +158,7 @@ const QueryBuilderStringEditor = ({ onChange, row }: QueryBuilderValueEditorProp
   );
 };
 
-const QueryBuilderBooleanEditor = ({ onChange, row }: QueryBuilderValueEditorProps) => {
+const QueryBuilderBooleanEditor = ({ onChange, row, disabled }: QueryBuilderValueEditorProps) => {
   return (
     <Switch
       checked={Boolean(row.value)}
@@ -166,6 +170,7 @@ const QueryBuilderBooleanEditor = ({ onChange, row }: QueryBuilderValueEditorPro
       }}
       color="primary"
       inputProps={{ 'aria-label': 'primary checkbox' }}
+      disabled={disabled}
     />
   );
 };
@@ -175,7 +180,7 @@ type QueryBuilderDateTimeEditorProps = QueryBuilderValueEditorProps & {
   expressionReferences?: ExpressionReference[];
 };
 
-const QueryBuilderDateTimeEditor = ({ expressionReferences, hasTime, onChange, row }: QueryBuilderDateTimeEditorProps) => {
+const QueryBuilderDateTimeEditor = ({ expressionReferences, hasTime, onChange, row, disabled }: QueryBuilderDateTimeEditorProps) => {
   const classes = useStyles();
 
   const isExpressionValid = useMemo(() => {
@@ -214,6 +219,7 @@ const QueryBuilderDateTimeEditor = ({ expressionReferences, hasTime, onChange, r
               value,
             });
           }}
+          disabled={disabled}
         />
       </MuiPickersUtilsProvider>
     );
@@ -249,6 +255,7 @@ const QueryBuilderDateTimeEditor = ({ expressionReferences, hasTime, onChange, r
           autoFocus
           value={row.expressionRef}
           onChange={event => handleExpressionRefChange(event.target.value as string)}
+          disabled={disabled}
         >
           {
             expressionReferences?.map((ref: ExpressionReference) => {
@@ -280,6 +287,7 @@ const QueryBuilderDateTimeEditor = ({ expressionReferences, hasTime, onChange, r
         error={!isExpressionValid}
         helperText={relativeTimeExpressionTooltip}
         placeholder={expressionFieldPlaceholder}
+        disabled={disabled}
       />
     );
   };
@@ -297,6 +305,7 @@ const QueryBuilderDateTimeEditor = ({ expressionReferences, hasTime, onChange, r
               <Checkbox
                 checked={row.expressionEnabled}
                 onChange={event => handleUseExpressionChange(event.target.checked)}
+                disabled={disabled}
               />
             </Tooltip>
           </Grid>
@@ -308,6 +317,7 @@ const QueryBuilderDateTimeEditor = ({ expressionReferences, hasTime, onChange, r
             <Checkbox
               checked={row.expressionEnabled}
               onChange={event => handleUseExpressionChange(event.target.checked)}
+              disabled={disabled}
             />
           </Tooltip>
         </>
@@ -320,7 +330,7 @@ type QueryBuilderValueRangeEditorProps = QueryBuilderValueEditorProps & {
   editorComponent: ReactElement<QueryBuilderValueEditorProps>;
 };
 
-const QueryBuilderValueRangeEditor = ({ editorComponent, onChange, row }: QueryBuilderValueRangeEditorProps) => {
+const QueryBuilderValueRangeEditor = ({ editorComponent, onChange, row, disabled }: QueryBuilderValueRangeEditorProps) => {
   // Convert the row value to a two-element array if necessary.
   useEffect(() => {
     let value = row.value;
@@ -361,6 +371,7 @@ const QueryBuilderValueRangeEditor = ({ editorComponent, onChange, row }: QueryB
               ...row,
               value: (row.value as QueryValueScalarType[])[index],
             },
+            disabled,
           })}
         </Grid>
       ))}
@@ -370,8 +381,8 @@ const QueryBuilderValueRangeEditor = ({ editorComponent, onChange, row }: QueryB
 
 const QueryBuilderEnumEditor = (props: QueryBuilderValueEditorProps) => {
   const classes = useStyles();
+  const { onChange, row, disabled } = props;
 
-  const { onChange, row } = props;
   return (
     <Select
       native
@@ -384,6 +395,7 @@ const QueryBuilderEnumEditor = (props: QueryBuilderValueEditorProps) => {
           value: event.target.value as string | number,
         });
       }}
+      disabled={disabled}
     >
       {row.field.enumItems!.map(({ label, value }) => (
         <option key={label} value={value}>

--- a/packages/client/src/components/query-builder/query-builder.tsx
+++ b/packages/client/src/components/query-builder/query-builder.tsx
@@ -28,8 +28,8 @@ export interface QueryBuilderProps {
   onChangeQueryRows: (queryRows: QueryRow[]) => void;
   onSaveClick: (queryRows: QueryRow[]) => void;
   hasChanges: boolean;
-  showAddCriteriaButton: boolean;
-  showSaveButton: boolean;
+  allowEdit?: boolean;
+  allowSave?: boolean;
 }
 
 export const QueryBuilder = (props: QueryBuilderProps) => {
@@ -40,8 +40,8 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
     onSaveClick,
     hasChanges,
     expressionRefsByType,
-    showAddCriteriaButton,
-    showSaveButton,
+    allowEdit = true,
+    allowSave = true,
   } = props;
 
   const classes = useStyles();
@@ -113,13 +113,14 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
                 onRemoveClick={removeRow(index)}
                 row={row}
                 expressionRefsByType={expressionRefsByType}
+                disabled={!allowEdit}
               />
             </Grid>
           ))}
         </Box>
       )}
 
-      {showAddCriteriaButton && (
+      {allowEdit && (
         <Button
           aria-label="Add Criteria"
           className={classes.button}
@@ -133,7 +134,7 @@ export const QueryBuilder = (props: QueryBuilderProps) => {
         </Button>
       )}
 
-      {showSaveButton && (
+      {allowSave && (
         <Button
           aria-label="Save"
           className={classes.button}

--- a/packages/client/src/components/view/view-layout.tsx
+++ b/packages/client/src/components/view/view-layout.tsx
@@ -18,10 +18,7 @@ import _ from 'lodash';
 import deepEquals from 'fast-deep-equal';
 import { Button } from '@material-ui/core';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
-import {
-  TableColumn,
-  TableRowOptions,
-} from '../tables/table-custom-columns-content';
+import { TableRowOptions } from '../tables/table-custom-columns-content';
 import { UserSelector } from '../../selectors/user.selector';
 import usePersistedState from '../../hooks/use-persisted-state';
 import { useAppSelector } from '../../hooks/use-app-selector';
@@ -92,6 +89,7 @@ export default function ViewLayout(props: ViewLayoutProps) {
   const dispatch = useAppDispatch();
 
   const orgId = useAppSelector(UserSelector.orgId)!;
+  const { canManageGroup } = useAppSelector(UserSelector.role)!;
 
   const [currentLayout, setCurrentLayout] = usePersistedState<SavedLayoutSerialized>(`${entityType}CurrentLayout`, makeDefaultViewLayout(entityType, [], maxTableColumns));
   const [selectedLayoutId, setSelectedLayoutId] = usePersistedState<ViewLayoutId>(`${entityType}SelectedLayoutId`, currentLayout.id);
@@ -369,10 +367,11 @@ export default function ViewLayout(props: ViewLayoutProps) {
                   onItemClick={selectLayout}
                   onItemDuplicateClick={handleSaveNewLayout}
                   onItemDeleteClick={handleDeleteClick}
-                  showItemDeleteButton={item => !isDefaultLayout(item.id)}
+                  showItemDuplicateButton={() => canManageGroup}
+                  showItemDeleteButton={layout => canManageGroup && !isDefaultLayout(layout.id)}
                 />
 
-                {hasChanges && (
+                {canManageGroup && hasChanges && (
                   <ViewLayoutButtons
                     selectedLayoutId={selectedLayoutId}
                     onSaveClick={handleSaveClick}

--- a/packages/client/src/components/view/view.tsx
+++ b/packages/client/src/components/view/view.tsx
@@ -82,6 +82,7 @@ export default function View({ layout, idColumn }: ViewProps) {
   const dispatch = useAppDispatch();
   const units = useAppSelector(UnitSelector.all);
   const orgId = useAppSelector(UserSelector.orgId)!;
+  const { canManageGroup } = useAppSelector(UserSelector.role)!;
 
   const [entitiesQuery, setEntitiesQuery] = usePersistedState<GetEntitiesQuery>(`${layout.name}EntitiesQuery`, {
     limit: '10',
@@ -143,7 +144,7 @@ export default function View({ layout, idColumn }: ViewProps) {
         enumItems,
       };
     });
-  }, [columns, units]);
+  }, [columns, entityType, units]);
 
   const fetchSavedFilters = useCallback(async () => {
     let savedFiltersNew: SavedFilterSerialized[];
@@ -381,19 +382,19 @@ export default function View({ layout, idColumn }: ViewProps) {
             onItemClick={selectFilter}
             onItemDuplicateClick={handleFilterDuplicateClick}
             onItemDeleteClick={handleFilterDeleteClick}
-            showItemDuplicateButton={isSavedFilter}
-            showItemDeleteButton={isSavedFilter}
+            showItemDuplicateButton={filter => canManageGroup && isSavedFilter(filter)}
+            showItemDeleteButton={filter => canManageGroup && isSavedFilter(filter)}
           />
 
           {selectedFilterId !== noFilterId && (
             <Button
-              aria-label="Toggle Filter Editor"
+              aria-label="Toggle Filter Settings"
               className={classes.tableHeaderButton}
               onClick={() => setFilterEditorOpen(!filterEditorOpen)}
               size="small"
               variant="outlined"
             >
-              {`${filterEditorOpen ? 'Hide' : 'Show'} Filter Editor`}
+              {`${filterEditorOpen ? 'Hide' : 'Show'} Filter Settings`}
             </Button>
           )}
         </Box>
@@ -407,8 +408,8 @@ export default function View({ layout, idColumn }: ViewProps) {
           onChangeQueryRows={handleChangeFilterQueryRows}
           onSaveClick={handleFilterSaveClick}
           hasChanges={filterHasChanges}
-          showAddCriteriaButton
-          showSaveButton
+          allowEdit={isCustomFilter(selectedFilterId) || canManageGroup}
+          allowSave={canManageGroup}
         />
       </Collapse>
 

--- a/packages/client/src/selectors/user.selector.ts
+++ b/packages/client/src/selectors/user.selector.ts
@@ -6,5 +6,5 @@ export namespace UserSelector {
   export const org = (state: AppState) => state.user.activeRole?.role.org;
   export const workspaces = (state: AppState) => state.user.activeRole?.role.workspaces;
   export const favoriteDashboards = (state: AppState) => state.user.activeRole?.favoriteDashboards;
-  export const canManageRoster = (state: AppState) => Boolean(state.user.activeRole?.role.canManageRoster);
+  export const role = (state: AppState) => state.user.activeRole?.role;
 }

--- a/packages/server/src/api/observation/observation.model.ts
+++ b/packages/server/src/api/observation/observation.model.ts
@@ -99,7 +99,7 @@ export class Observation extends BaseEntity {
     const reportSchema = await ReportSchema.findOne({
       where: {
         org: org.id,
-        id: version,
+        ...(version && { id: version }),
       },
     });
 

--- a/packages/server/src/api/saved-filter/saved-filter.controller.ts
+++ b/packages/server/src/api/saved-filter/saved-filter.controller.ts
@@ -19,14 +19,11 @@ class SavedFilterController {
   async getSavedFilters(req: ApiRequest<null, null, GetSavedFiltersQuery>, res: Response) {
     const { entityType } = req.query;
 
-    const savedFilters = await SavedFilter.find({
-      relations: ['org'],
-      where: {
-        org: req.appOrg!.id,
-        ...(entityType && { entityType }),
-      },
-      order: { name: 'ASC' },
-    });
+    const savedFilters = await SavedFilter.getAllowedSavedFilters(
+      req.appOrg!,
+      req.appUserRole!.role,
+      entityType,
+    );
 
     res.json(savedFilters);
   }

--- a/packages/server/src/api/saved-layout/saved-layout.controller.ts
+++ b/packages/server/src/api/saved-layout/saved-layout.controller.ts
@@ -19,14 +19,11 @@ class SavedLayoutController {
   async getSavedLayouts(req: ApiRequest<null, null, GetSavedLayoutsQuery>, res: Response) {
     const { entityType } = req.query;
 
-    const savedLayouts = await SavedLayout.find({
-      relations: ['org'],
-      where: {
-        org: req.appOrg!.id,
-        ...(entityType && { entityType }),
-      },
-      order: { name: 'ASC' },
-    });
+    const savedLayouts = await SavedLayout.getAllowedSavedLayouts(
+      req.appOrg!,
+      req.appUserRole!.role,
+      entityType,
+    );
 
     res.json(savedLayouts);
   }

--- a/packages/server/src/util/entity-column-utils.ts
+++ b/packages/server/src/util/entity-column-utils.ts
@@ -1,0 +1,44 @@
+import {
+  ColumnInfo,
+  ColumnsConfig,
+  EntityType,
+  FilterConfig,
+  getFullyQualifiedColumnName,
+} from '@covid19-reports/shared';
+import _ from 'lodash';
+import { Org } from '../api/org/org.model';
+import { Roster } from '../api/roster/roster.model';
+import { Observation } from '../api/observation/observation.model';
+
+export type EntityColumnLookup = {
+  [K in EntityType]: {
+    [columnName: string]: ColumnInfo;
+  }
+};
+
+export async function buildEntityColumnLookup(org: Org): Promise<EntityColumnLookup> {
+  return {
+    roster: _.keyBy(await Roster.getColumns(org), x => x.name),
+    observation: _.keyBy(await Observation.getColumns(org), x => x.name),
+  };
+}
+
+export function getRequiredPermissionsForColumns(
+  columnsConfig: ColumnsConfig | FilterConfig,
+  entityColumnLookup: EntityColumnLookup,
+) {
+  const columns: ColumnInfo[] = [];
+  for (const columnLookup of _.values(entityColumnLookup)) {
+    for (const column of _.values(columnLookup)) {
+      const fullyQualifiedColumnName = getFullyQualifiedColumnName(column);
+      if (columnsConfig[fullyQualifiedColumnName]) {
+        columns.push(column);
+      }
+    }
+  }
+
+  return {
+    pii: _.some(columns, column => column.pii),
+    phi: _.some(columns, column => column.phi),
+  };
+}

--- a/packages/shared/src/base-entity-columns.ts
+++ b/packages/shared/src/base-entity-columns.ts
@@ -1,0 +1,28 @@
+import {
+  baseRosterColumnLookup,
+  baseRosterColumns,
+} from './roster.types';
+import {
+  baseObservationColumnLookup,
+  baseObservationColumns,
+} from './observation.types';
+import {
+  ColumnInfo,
+  EntityType,
+} from './entity.types';
+
+export const baseEntityColumns: {
+  [K in EntityType]: ColumnInfo[]
+} = {
+  roster: baseRosterColumns,
+  observation: baseObservationColumns,
+};
+
+export const baseEntityColumnsLookup: {
+  [K in EntityType]: {
+    [columnName: string]: ColumnInfo;
+  }
+} = {
+  roster: baseRosterColumnLookup,
+  observation: baseObservationColumnLookup,
+};

--- a/packages/shared/src/saved-layout.types.ts
+++ b/packages/shared/src/saved-layout.types.ts
@@ -9,8 +9,13 @@ export type ActionConfig = {
   order: number;
 };
 
-export type ColumnsConfig = Record<string, ColumnConfig>;
-export type ActionsConfig = Record<string, ColumnConfig>;
+export type ColumnsConfig = {
+  [fullyQualifiedColumnName: string]: ColumnConfig;
+};
+
+export type ActionsConfig = {
+  [fullyQualifiedColumnName: string]: ColumnConfig;
+};
 
 export type SavedLayoutSerialized = {
   id: number;

--- a/packages/shared/src/utils/entity-column-utils.ts
+++ b/packages/shared/src/utils/entity-column-utils.ts
@@ -33,7 +33,7 @@ export function getFullyQualifiedColumnName(column: FullyQualifiedColumnNamePart
     : columnName;
 }
 
-function getFullyQualifiedColumnNameParts(fullyQualifiedName: string): FullyQualifiedColumnNameParts {
+export function getFullyQualifiedColumnNameParts(fullyQualifiedName: string): FullyQualifiedColumnNameParts {
   const parts = fullyQualifiedName.split(delimiters.table);
   if (parts.length < 1 && parts.length > 2) {
     throw new Error('Column path must be in format {table}.{columnName}');


### PR DESCRIPTION
https://app.asana.com/0/1188940305683068/1200945013709290
https://app.asana.com/0/1188940305683068/1200849131245333

Only users with `canManageGroup` permissions should now be able to modify saved filters/layouts in any way. For a user without `canManageGroup` permissions, they should still be able to setup a custom filter or layout, but won't have any way to save (aside from automatic local persistence).

Users should also only see filters/layouts with columns that they have permissions for. So if a filter/layout has one or more columns requiring pii, then users without pii permissions shouldn't see the filter/layout.

## Admin
<img width="747" alt="Screen Shot 2021-10-01 at 12 52 39 PM" src="https://user-images.githubusercontent.com/3220897/135679645-05a6d452-d210-496b-8e23-80d3be548f51.png">

<img width="653" alt="Screen Shot 2021-10-01 at 12 52 49 PM" src="https://user-images.githubusercontent.com/3220897/135679662-eb65c0f5-ed37-4a1a-a8a2-de7b6c054d39.png">

<img width="813" alt="Screen Shot 2021-10-01 at 12 54 40 PM" src="https://user-images.githubusercontent.com/3220897/135679686-3b72e9a7-26f8-40a2-abb1-d6a07bb1c5b0.png">


## Non-Admin
<img width="719" alt="Screen Shot 2021-10-01 at 12 53 56 PM" src="https://user-images.githubusercontent.com/3220897/135679740-038a448f-0e7e-4d31-adee-c9855a27de50.png">

<img width="766" alt="Screen Shot 2021-10-01 at 12 54 11 PM" src="https://user-images.githubusercontent.com/3220897/135679761-9b48e0fc-0e2f-468d-8481-b438da26bf99.png">

<img width="830" alt="Screen Shot 2021-10-01 at 12 54 03 PM" src="https://user-images.githubusercontent.com/3220897/135679749-3d0984af-93a3-49ea-9163-17913a622d5b.png">
